### PR TITLE
Fix for domain import

### DIFF
--- a/ghostwriter/shepherd/templates/shepherd/domain_import.html
+++ b/ghostwriter/shepherd/templates/shepherd/domain_import.html
@@ -11,14 +11,14 @@
         <div class="form-group">
             <label for="csv_file" class="csvlabel">
                 <div class="csvdiv">Click or drop your csv file here</div>
-                <input type="file" id="csv_file" name="csv_file" required="True"> 
+                <input type="file" id="csv_file" name="csv_file" required="True">
             </label>
             <p id="filename"></p>
         </div>
         <div class="form-group">
             <div style="text-align: center"></div>
                 <button class="button"><i class="fas fa-file-upload"></i> Upload</button>
-            </div> 
+            </div>
         </div>
     </form>
 
@@ -43,7 +43,7 @@
         </p>
 
         {% load static %}
-        <a href="{% static 'files/template.csv' %}" style="margin-bottom: 20px" class="button"><i class="fas fa-file-download"></i> Download Template</a>
+        <a href="{% static 'files/template_domain.csv' %}" style="margin-bottom: 20px" class="button"><i class="fas fa-file-download"></i> Download Template</a>
 
         <!-- Spacer -->
         <p style="margin: 40px;"></p>

--- a/ghostwriter/shepherd/templates/shepherd/server_import.html
+++ b/ghostwriter/shepherd/templates/shepherd/server_import.html
@@ -11,14 +11,14 @@
         <div class="form-group">
             <label for="csv_file" class="csvlabel">
                 <div class="csvdiv">Click or drop your csv file here</div>
-                <input type="file" id="csv_file" name="csv_file" required="True"> 
+                <input type="file" id="csv_file" name="csv_file" required="True">
             </label>
             <p id="filename"></p>
         </div>
         <div class="form-group">
             <div style="text-align: center"></div>
                 <button class="button"><i class="fas fa-file-upload"></i> Upload</button>
-            </div> 
+            </div>
         </div>
     </form>
 
@@ -43,7 +43,7 @@
         </p>
 
         {% load static %}
-        <a href="{% static 'files/template.csv' %}" style="margin-bottom: 20px" class="button"><i class="fas fa-file-download"></i> Download Template</a>
+        <a href="{% static 'files/template_server.csv' %}" style="margin-bottom: 20px" class="button"><i class="fas fa-file-download"></i> Download Template</a>
     </div>
 {% endblock %}
 

--- a/ghostwriter/shepherd/views.py
+++ b/ghostwriter/shepherd/views.py
@@ -454,7 +454,7 @@ def import_servers(request):
     try:
         # Process each csv row and commit it to the database
         for entry in csv_reader:
-            print(entry)
+            #print(entry)
             logging.getLogger('error_logger').info(
                 'Adding %s to the database',
                 entry['ip_address'])
@@ -499,8 +499,11 @@ def import_servers(request):
             # Try to pass the dict object to the `StaticServer` model
             try:
                 # First, check if a server with this address exists
-                instance = StaticServer.objects.get(
-                    ip_address=entry['ip_address'])
+                try:
+                    instance = StaticServer.objects.get(
+                        ip_address=entry['ip_address'])
+                except Exception:
+                    instance = False
                 if instance:
                     # This server already exists so update that entry
                     for attr, value in entry.items():

--- a/ghostwriter/shepherd/views.py
+++ b/ghostwriter/shepherd/views.py
@@ -374,7 +374,7 @@ def import_domains(request):
                 # First, check if a domain with this name exists
                 try:
                     instance = Domain.objects.get(name=entry['name'])
-                except Exception:
+                except Domain.DoesNotExist:
                     instance = False
                 if instance:
                     # This domain already exists so update that entry
@@ -502,7 +502,7 @@ def import_servers(request):
                 try:
                     instance = StaticServer.objects.get(
                         ip_address=entry['ip_address'])
-                except Exception:
+                except StaticServer.DoesNotExist:
                     instance = False
                 if instance:
                     # This server already exists so update that entry

--- a/ghostwriter/shepherd/views.py
+++ b/ghostwriter/shepherd/views.py
@@ -372,7 +372,10 @@ def import_domains(request):
             # Try to pass the dict object to the `Domain` model
             try:
                 # First, check if a domain with this name exists
-                instance = Domain.objects.get(name=entry['name'])
+                try:
+                    instance = Domain.objects.get(name=entry['name'])
+                except Exception:
+                    instance = False
                 if instance:
                     # This domain already exists so update that entry
                     for attr, value in entry.items():
@@ -386,7 +389,7 @@ def import_domains(request):
             except Exception as e:
                 messages.error(
                     request,
-                    'Failed parsing %s: %s' % (entry['ip_address'], e),
+                    'Failed parsing %s: %s' % (entry['name'], e),
                     extra_tags='alert-danger')
                 logging.getLogger('error_logger').error(repr(e))
                 pass

--- a/ghostwriter/static/files/template.csv
+++ b/ghostwriter/static/files/template.csv
@@ -1,2 +1,0 @@
-﻿name,registrar,health_status, health_dns, dns_record, whois,creation,expiration,ibm_xforce_cat,talos_cat,bluecoat_cat,fortiguard_cat,opendns_cat,trendmicro_cat,mx_toolbox_status,note,domain_status
- specterops.io, SpecterHops Domain Names, Healthy, Healthy, 127.0.0.1, Enabled, 2017-01-26, 2019-01-26, Technology, Technology, Uncategorized, Uncategorized, Uncategorized, Uncategorized, No Issues, This is a note, Available

--- a/ghostwriter/static/files/template_domain.csv
+++ b/ghostwriter/static/files/template_domain.csv
@@ -1,0 +1,2 @@
+﻿name,registrar,health_status,health_dns,dns_record,whois,creation,expiration,ibm_xforce_cat,talos_cat,bluecoat_cat,fortiguard_cat,opendns_cat,trendmicro_cat,mx_toolbox_status,note,domain_status
+specterops.io, SpecterHops Domain Names, Healthy, Healthy, 127.0.0.1, Enabled, 2017-01-26, 2019-01-26, Technology, Technology, Uncategorized, Uncategorized, Uncategorized, Uncategorized, No Issues, This is a note, Available

--- a/ghostwriter/static/files/template_server.csv
+++ b/ghostwriter/static/files/template_server.csv
@@ -1,0 +1,2 @@
+ip_address,server_status,server_provider,note
+127.0.0.1,Available,Microsoft Azure,Test server


### PR DESCRIPTION
This PR fixes 2 issues in the `import_domains` function:

1. If the domain didn't exist, the `Domain.objects.get(name=entry['name'])` function throws an error => surrounded by a try/except
2. The overall exception handling of the function was using the `ip_address` key, which is not in the domain model (probably bad copy/paste from the server import)