### PR TITLE
remove comment from nginx dockerfile

### DIFF
--- a/compose/production/nginx/Dockerfile
+++ b/compose/production/nginx/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:latest
-# ADD nginx.conf /etc/nginx/nginx.conf
+ADD nginx.conf /etc/nginx/nginx.conf
 
 


### PR DESCRIPTION
Seems the Dockerfile had the copy in line commented for some reason, I don't think it was meant to be like that... (resolves 502 errors)