### PR TITLE
Align nginx config with Mozilla Guideline 5.4

### DIFF
--- a/compose/production/nginx/nginx.conf
+++ b/compose/production/nginx/nginx.conf
@@ -40,6 +40,7 @@ http {
     # Begin SSL site setup
     server {
         listen 443 ssl http2 default_server;
+        listen [::]:443 ssl http2;
         server_name ghostwriter.local;
         charset     utf-8;
 
@@ -48,16 +49,21 @@ http {
         # ssl on;
         ssl_certificate /ssl/ghostwriter.crt;
         ssl_certificate_key /ssl/ghostwriter.key;
+        ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+        ssl_session_tickets off;
+        ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+        ssl_prefer_server_ciphers off;    
         #ssl_stapling on;
         #ssl_stapling_verify on;
 
         # SSL from stock default's  ssl section
         ssl_session_timeout 60m;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
         ssl_dhparam /ssl/dhparam.pem;
-        ssl_prefer_server_ciphers on;
         resolver 8.8.8.8;
+    
+        # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+        add_header Strict-Transport-Security "max-age=63072000" always;
 
         location /media {
             alias /app/media;


### PR DESCRIPTION
https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&ocsp=false&guideline=5.4

This changes:
* Enable the listener on both IPv4 and IPv6
* More restrictive TLS versions for higher security and the addition of TLSv1.3
* Support for a wider variety of well-known secure ciphers
* HTTPS Strict Transport Security to ensure TLS is the primary means of accessing the service
* Use a shared SSL cache between all worker processes for better performance
* Disables session resumption via TLS session tickets
* Return the prefer server ciphers to the default of off. When paired with the cipher list this is not a required field