### PR TITLE
Fix typo — "Instuctions"

### DIFF
--- a/ghostwriter/reporting/templates/reporting/local_edit.html
+++ b/ghostwriter/reporting/templates/reporting/local_edit.html
@@ -20,7 +20,7 @@
         <div class="card">
             <div class="card-header" id="keyword" data-toggle="collapse" data-target="#collapseKeyword">
                 <a class="accordion-toggle btn btn-link" data-toggle="collapse" data-target="#collapseKeyword" aria-expanded="false" aria-controls="collapseKeyword">
-                    <i class="fas fa-code"></i> Keyword Reference & Instuctions
+                    <i class="fas fa-code"></i> Keyword Reference & Instructions
                 </a>
             </div>
             <div id="collapseKeyword" class="collapse" aria-labelledby="keyword" data-parent="#accordion">


### PR DESCRIPTION
Fixes the typo from "Instuctions" to "Instructions"