### PR TITLE
[Fix #60] Ensure a span has a class

### DIFF
--- a/ghostwriter/modules/reportwriter.py
+++ b/ghostwriter/modules/reportwriter.py
@@ -445,7 +445,7 @@ class Reportwriter():
             if '</code' in word:
                 self.inline_code = False
                 continue
-            if '<span' in word and '</span' not in word:
+            if '<span' in word and '</span' not in word and 'class=' in word:
                 # When two or more styles are applied, TinyMCE uses a span:
                 # e.g., <span class="bold italic">
                 regex = r'(?<=class=").*?(?=">)'


### PR DESCRIPTION
Fix #60 

Ensure that if we have found a span class item, that it has a class assigned to it (e.g. from TinyMCE) and it's not holdover from a copy and paste style