### PR TITLE
Improved upload evidence UI

### DIFF
--- a/ghostwriter/reporting/templates/reporting/local_edit.html
+++ b/ghostwriter/reporting/templates/reporting/local_edit.html
@@ -34,7 +34,7 @@
                         _dialog = editor.windowManager.openUrl({
                             title: 'Upload Evidence',
                             url: '{% url "reporting:upload_evidence_modal" reportfindinglink.id %}',
-                            height: 1100,
+                            height: 900,
                             width: 1000,
                             buttons: [
                                 {


### PR DESCRIPTION
When using GhostWriter in a VM the upload evidence modal overflows. Hiding the close window and submit evidence button.

Best is to have percentage based height. However tinymce windowManager.openUrl() does not support this.