### PR TITLE
Bug Fix - Fix ws_user message parsing on base templates

### DIFF
--- a/ghostwriter/templates/base_generic.html
+++ b/ghostwriter/templates/base_generic.html
@@ -462,7 +462,7 @@
 
                 // Handle receiving messages on channels
                 ws_user.onmessage = function (e) {
-                  var data = JSON.parse(e.data);
+                  var data = JSON.parse(e.data).message;
                   if (data.assignments !== undefined) {
                     document.getElementById('assignment-count').innerHTML = data.assignments
                   }

--- a/ghostwriter/templates/base_generic_empty.html
+++ b/ghostwriter/templates/base_generic_empty.html
@@ -209,7 +209,7 @@
 
                 // Handle receiving messages on channels
                 ws_user.onmessage = function (e) {
-                  var data = JSON.parse(e.data);
+                  var data = JSON.parse(e.data).message;
                   if (data.assignments !== undefined) {
                     document.getElementById('assignment-count').innerHTML = data.assignments
                   }


### PR DESCRIPTION
The current project generates the following error when testing api configurations:

```
toastr.js:474 Uncaught TypeError: e.replace is not a function
```

This is due to incorrect parsing of the incoming message object. This pull request fixes the parsing logic. In all honesty, I didn't see anything else this should break, but more thorough testing is welcomed :) 

## To reproduce the error 
1. Log into GhostWriter
2. Visit the /home/management/ route (or click Review Configuration on the left-hand menu)
3. Test any API that you have configured 
4. Note the error in the javascript console 
