### PR TITLE
Add project_codename variable for in Word template

### DIFF
--- a/ghostwriter/modules/reportwriter.py
+++ b/ghostwriter/modules/reportwriter.py
@@ -1646,6 +1646,7 @@ class Reportwriter:
         # Assessment information
         context["assessment_name"] = self.report_json["project"]["name"]
         context["assessment_type"] = self.report_json["project"]["project_type"]
+        context["project_codename"] = self.report_json["project"]["codename"]
         context["project_type"] = context["assessment_type"]
         context["company"] = self.company_config.company_name
         context["company_pocs"] = self.report_json["team"].values()
@@ -2276,6 +2277,7 @@ class TemplateLinter:
                     # Assessment information
                     context["assessment_name"] = ""
                     context["assessment_type"] = ""
+                    context["project_codename"] = ""
                     context["project_type"] = ""
                     context["company"] = ""
                     context["company_pocs"] = ""


### PR DESCRIPTION
Added project_codename variable. Allowing use of the project codename in Word. Codename is customizable in GW2.0, waste not to be able to use it separately in Word.