### PR TITLE
Bugfix - Production Django Container Restart Loop

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -45,6 +45,8 @@ RUN chmod +x /seed_data
 
 RUN mkdir -p /app/staticfiles
 
+RUN mkdir -p /app/ghostwriter/media
+
 RUN chown -R django /app
 
 USER django


### PR DESCRIPTION
The production django container would get stuck in a restart loop due do a lack of permission on the /app/ghostwriter/media folder.

Running mkdir /app/ghostwriter/media prior to chown -R django /app in the Dockerfile corrects this issue.