### PR TITLE
BugFix - Reports failing to generate due to null fields

### DIFF
--- a/ghostwriter/modules/reportwriter.py
+++ b/ghostwriter/modules/reportwriter.py
@@ -1427,10 +1427,9 @@ Try opening it, exporting as desired type, and re-uploading it."
         """
         prev_p = None
 
-        # Clean text to make it XML compatible for Office XML
-        text = "".join(c for c in text if self.valid_xml_char_ordinal(c))
-
         if text:
+            # Clean text to make it XML compatible for Office XML
+            text = "".join(c for c in text if self.valid_xml_char_ordinal(c))
             # Parse the HTML into a BS4 soup object
             soup = BeautifulSoup(text, "lxml")
             # Each WYSIWYG field begins with `<html><body>` so get the contents of body


### PR DESCRIPTION
After merging new commits onto my old custom GW 1.0 fork, I found that reports would fail to generate because the `ReportFindingLink` model allowed some null fields that actually ended up defaulting to null after the database migrations. These null fields made it out to `process_text_xml()` through `process_richtext()`. This fix is to make sure that the report generation doesn't error out when this edge case happens.