### PR TITLE
Bump ``djangorestframework-api-key`` to 2.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ django-bleach==1.0.0
 django-filter==2.4.0
 django-import-export==2.7.1
 django-q==1.3.9
-djangorestframework-api-key==2.0.0
+djangorestframework-api-key==2.2.0
 django-tinymce==3.4.0  # Deprecated, but kept here for legacy migrations
 docutils==0.18.1
 docxtpl==0.12.0


### PR DESCRIPTION
## Changed

* Bumped ``djangorestframework-api-key`` to 2.2.0 (fixes #197)