### PR TITLE
Adding the ability to paste screenshots into evidence and image preview

### DIFF
--- a/ghostwriter/reporting/forms.py
+++ b/ghostwriter/reporting/forms.py
@@ -594,7 +594,8 @@ class EvidenceForm(forms.ModelForm):
                 """
                 <h4 class="icon upload-icon">Upload a File</h4>
                 <hr>
-                <p>Attach text evidence (*.txt, *.log, or *.md) or image evidence (*.png, *.jpg, or *.jpeg).</p>
+                <div id="findingPreview">Attach text evidence (*.txt, *.log, or *.md) or image evidence (*.png, *.jpg, or *.jpeg).</div>
+                <hr>
                 """
             ),
             Div(

--- a/ghostwriter/reporting/templates/reporting/evidence_form_template.html
+++ b/ghostwriter/reporting/templates/reporting/evidence_form_template.html
@@ -31,7 +31,7 @@
             previewDiv.innerHTML="A preview was not loaded. Evidence type was "+ fileInput.files[0].type
         }
     }
-    $(window).on('paste', function() {
+    $(window).on('paste', function(e) {
         fileInput = document.getElementById('id_document')
         // use event.originalEvent.clipboard for newer chrome versions
         var pastedFileObj = (e.clipboardData  || e.originalEvent.clipboardData);

--- a/ghostwriter/reporting/templates/reporting/evidence_form_template.html
+++ b/ghostwriter/reporting/templates/reporting/evidence_form_template.html
@@ -19,7 +19,31 @@
 
 <!-- Script for File Upload -->
 <script>
+    function renderPreview() {
+        fileInput = document.getElementById('id_document')
+        previewDiv=document.getElementById("findingPreview")
+        if (fileInput.files[0].type.indexOf("image")==0){
+            previewDiv.innerHTML='<img id="loadedImage" alt="image"/ >' 
+            loadedImage.src =URL.createObjectURL(fileInput.files[0])
+            loadedImage.style.border = "thin solid #555555"; 
+        } else {
+            //todo - read X lines from text file?
+            previewDiv.innerHTML="A preview was not loaded. Evidence type was "+ fileInput.files[0].type
+        }
+    }
+    $(window).on('paste', function() {
+        fileInput = document.getElementById('id_document')
+        // use event.originalEvent.clipboard for newer chrome versions
+        var pastedFileObj = (e.clipboardData  || e.originalEvent.clipboardData);
+
+        if (pastedFileObj.files.length){
+            fileInput.files = pastedFileObj.files
+            filename.textContent = 'C:\\fakepath\\'+fileInput.files[0].name
+            renderPreview()
+        }
+    });
     $('input[type=file]').on('change', function() {
         $("#filename").text($(this).val());
+        renderPreview()
     });
 </script>


### PR DESCRIPTION
I added a preview div above the evidence input.

It will generate an <img> if the uploaded evidence is an image. I achieved this by creating a renderPreview function.

Additionally, added an event listener looking for paste in the window. If that paste had files attached, it will add them to the input and run the renderPreview function.

Documentation-wise, it may be handy to add that images/files can be pasted into the evidence pages.

