### PR TITLE
Clone evidence when cloning a report

### DIFF
--- a/ghostwriter/reporting/views.py
+++ b/ghostwriter/reporting/views.py
@@ -704,9 +704,20 @@ class ReportClone(LoginRequiredMixin, SingleObjectMixin, View):
             report_to_clone.save()
             new_report_pk = report_to_clone.pk
             for finding in findings:
+                evidences = Evidence.objects.select_related("finding").filter(
+                    finding=finding.pk
+                )
                 finding.report = report_to_clone
                 finding.pk = None
                 finding.save()
+
+                for evidence in evidences:
+                    evidence_file = File(evidence.document, os.path.basename(evidence.document.name))
+                    evidence.finding = finding
+                    evidence._current_evidence = None
+                    evidence.document = evidence_file
+                    evidence.pk = None
+                    evidence.save()
 
             logger.info(
                 "Cloned %s %s by request of %s",


### PR DESCRIPTION
### Issue

Currently, only the findings are copied over when cloning a report, which means that the evidence for each finding will not be copied over.

### Description of the Change

The updated functionality will clone all the evidence for each finding similarly to how each finding is cloned. Furthermore, the files will also be copied over on the filesystem, such that there is no link between the old and new report. If the files aren't copied over on the filesystem, then deleting the clone of the report will also delete the evidence files.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Create a new report with evidence. Clone the report. Verify that both reports have the evidence. Verify that deleting or modifying any of the evidence in one report doesn't affect the other report. Verify that deleting the any of the reports does not affect the evidence of the other report.

### Release Notes

Clone evidence when cloning a report
