### PR TITLE
Update restore to delete current connections to the database

### DIFF
--- a/compose/production/postgres/maintenance/restore
+++ b/compose/production/postgres/maintenance/restore
@@ -43,6 +43,12 @@ export PGUSER="${POSTGRES_USER}"
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 export PGDATABASE="${POSTGRES_DB}"
 
+
+### It's Required to terminate current connections to delete the database
+message_info "Cleaning connections to the database..."
+
+psql -c "REVOKE CONNECT ON DATABASE ${PGDATABASE} FROM public; ALTER database ${POSTGRES_DB} allow_connections = off; SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '${PGDATABASE}';" postgres
+
 message_info "Dropping the database..."
 dropdb "${PGDATABASE}"
 


### PR DESCRIPTION
### Description of the Change

Postgres require that the target database doesn't have connections before it being deleted. Otherwise it will raise an error. On postgres 13+ the dropdb command has the --force option that terminates the connections forcefully. For older versions of postgres we need to kill the current connections manually. This change updates the restore script to terminate the current connections to the ghostwriter database before deleting it since ghostwriter uses postgres 11.

### Alternate Designs

Use postgres 13 and modify the dropdb command with the --force flag.

### Possible Drawbacks

The change doesn't expect any drawbacks or unexpected behaviour.

### Verification Process

Executed the following command and observed that the database restoration worked properly, before the changes postgres would not perform the restoration since there were active connections to the database:

```
./ghostwriter-cli restore database.tgz
```
### Release Notes

Added connection revoke to restore database script. Now the database restoration will work properly without the need to manually delete the current db connections.
