### PR TITLE
Update Dockerfile

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -52,7 +52,7 @@ RUN sed -i 's/\r$//g' /seed_data \
     && chmod +x /seed_data \
     && mkdir -p /app/staticfiles \
     && mkdir -p /app/ghostwriter/media \
-    && chown -R django /app
+    && chown -R django:django /app
 
 USER django
 


### PR DESCRIPTION
Fixes cp: can't stat '/app/ghostwriter/reporting/templates/reports/template.docx': No such file or directory

### Identify the Bug

This pull requests fixes the following issue: https://github.com/GhostManager/Ghostwriter/issues/347

### Description of the Change

The FAQ describes how to use chown django:django to resolve the issue. However the FAQ doesn't make persistent changes and as such following the FAQ doesn't really help (https://www.ghostwriter.wiki/getting-help/faq#stuck-waiting-for-django-to-start-502-bad-gateway)

Changing the dockerfile to include django:django did however solve the issue.

### Verification Process
Did ghostwriter-cli install and now Django works.

### Release Notes

- Fixed ``cp: can't stat '/app/ghostwriter/reporting/templates/reports/template.docx': No such file or directory`` error
