### PR TITLE
Fix issue with single quotes in finding names

### DIFF
--- a/ghostwriter/reporting/templates/reporting/finding_list.html
+++ b/ghostwriter/reporting/templates/reporting/finding_list.html
@@ -176,7 +176,7 @@
     $(function () {
       let availableTitles = [
         {% for entry in autocomplete %}
-          '{{ entry|bleach }}',
+          '{{ entry|escapejs }}',
         {% endfor %}
       ];
       $("#id_title").autocomplete({


### PR DESCRIPTION
The finding_list.html uses bleach to sanitize the finding name, which is incorrect in JS code and can lead to XSS attacks. This patch uses the correct "escapejs" one.

### Requirements for Contributing a Bug Fix

### Identify the Bug

`finding_list.html` uses incorrect escaping for finding names in the autocomplete list, leading to issues with findings with single quotes in the name. This was reported by hxfifty in the BloodHoundGang Slack.

### Description of the Change

Swap using `bleach`, which only filters HTML content, with `escapejs`, which correctly escapes JS code.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Created a finding with a single quote in the name

### Release Notes

Fix issue with the findings list with findings that have a single quote in their name

<!--

Please describe the changes in a single line that explains this improvement in terms that a user can understand. This text will be used in Ghostwriter's release notes.

If this change is not user-facing or notable enough to be included in release notes you may use the strings "Not applicable" or "N/A" here.

Examples:

- Fixed ``Import Oplog`` button URL

