### PR TITLE
Fix error with rendering a report with no findings

### DIFF
--- a/ghostwriter/modules/reportwriter.py
+++ b/ghostwriter/modules/reportwriter.py
@@ -1572,10 +1572,11 @@ class Reportwriter:
                 return self.sacrificial_doc
             return None
 
+        p_style = self.report_queryset.docx_template.p_style
+
         # Findings
         for finding in context["findings"]:
             logger.info("Processing %s", finding["title"])
-            p_style = self.report_queryset.docx_template.p_style
             # Create ``RichText()`` object for a colored severity category
             finding["severity_rt"] = RichText(finding["severity"], color=finding["severity_color"])
             finding["cvss_score_rt"] = RichText(finding["cvss_score"], color=finding["severity_color"])


### PR DESCRIPTION

### Identify the Bug

Attempting to render a report that does not have an associated finding results in an error: "Encountered an error generating the document: local variable `p_style` referenced before assignment"

### Description of the Change

Move initialization of `p_style` above the `for` loop that it currently is in to unconditionally initialize it.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Rendered an empty report with no findings and verified that it rendered OK

### Release Notes

- Fixed rendering reports that have no associated findings

