### PR TITLE
Nmap fix

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -21,6 +21,8 @@ RUN apk --no-cache add build-base curl \
     # Rust and Cargo required by the ``cryptography`` Python package
     && apk --no-cache add rust \
     && apk --no-cache add cargo \
+    # Nmap required by the ``python-nmap`` Python package.
+    && apk --no-cache add nmap \
     && pip install --no-cache-dir -U setuptools pip
 
 COPY ./requirements /requirements

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -17,6 +17,8 @@ RUN apk --no-cache add build-base curl \
     # Rust and Cargo required by the ``cryptography`` Python package
     && apk --no-cache add rust \
     && apk --no-cache add cargo \
+    # Nmap required by the ``python-nmap`` Python package. libcap used to set the capabilities of nmap so root is not required
+    && apk --no-cache add nmap libcap \
     && addgroup -S django \
     && adduser -S -G django django \
     && pip install --no-cache-dir -U setuptools pip
@@ -45,6 +47,11 @@ COPY ./compose/production/django/queue/start /start-queue
 RUN sed -i 's/\r//' /start-queue \
     && chmod +x /start-queue \
     && chown django /start-queue
+
+RUN chown django:django /usr/bin/nmap \
+    && chmod 750 /usr/bin/nmap
+
+RUN setcap cap_net_raw,cap_net_bind_service+eip /usr/bin/nmap
 
 COPY ./compose/production/django/seed_data /seed_data
 

--- a/production.yml
+++ b/production.yml
@@ -53,6 +53,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/0
       - WEB_CONCURRENCY=${DJANGO_WEB_CONCURRENCY}
+      - NMAP_PRIVILEGED=""
     healthcheck:
       test: curl --insecure --fail https://nginx/status/simple/ || exit 1
       interval: ${HEALTHCHECK_INTERVAL}


### PR DESCRIPTION
### Issue
https://github.com/GhostManager/Ghostwriter/issues/357

### Description of the Change

This change adds the nmap binary to both local and production django containers.

Production django container is not running as root and cannot run an nmap scan with `-sS`:
- `libcap` has been added to the production docker container in order to set the nmap binary capabilities so as to not require root
- An NMAP_PRIVILEGED environment variable has also been added to tell the nmap binary that it has the required capabilities already instead of checking for root

### Alternate Designs

Running the container as root in production is a security risk. So this was not explored.
Nmap can be used without priviledges using the environment variable or using a `--privileged` option. Using the `--privileged` option would require this to be added to the rolodex tasks function instead.

### Possible Drawbacks

Nmap is installed on the container potentially allowing anyone who has access to the container cli to run a SYN scan against the localhost or other servers not owned by the user

### Verification Process

- Checked the Dockerfile setup the `queue` container as expected - correct binarys installed, cap's set correctly, env variable set
- Run the nmap binary on the container using docker exec - nmap binary runs without error
- Spun up the production containers and added a task to scan servers - task completes without error

### Release Notes

- Added nmap binary to local and production Dockerfile's
- Set capabilities on nmap binary so root priviledges are not required

