### PR TITLE
Fix improper escaping of finding names in report detail page

### DIFF
--- a/ghostwriter/reporting/templates/reporting/report_detail.html
+++ b/ghostwriter/reporting/templates/reporting/report_detail.html
@@ -750,7 +750,7 @@
     $(function () {
       let availableTitles = [
         {% for entry in autocomplete %}
-          '{{ entry|bleach }}',
+          '{{ entry|escapejs }}',
         {% endfor %}
       ];
       $("#id_search").autocomplete({


### PR DESCRIPTION

### Identify the Bug

Issue #374 

### Description of the Change

In the report detail template, fix escaping of the finding title to use the proper Javascript escaping. 

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Created a finding named `'];alert(0);let testx = ['a` and a test report. Viewed the test report's detail page with and without the patch. Tested adding the finding to the report.

### Release Notes

- Fix improper escaping of finding names in report detail page
