### PR TITLE
Use jinja templating for report filenames

### DIFF
--- a/ghostwriter/commandcenter/migrations/0025_report_filename_template_convert.py
+++ b/ghostwriter/commandcenter/migrations/0025_report_filename_template_convert.py
@@ -1,0 +1,41 @@
+
+import re
+
+from django.db import migrations, models
+
+def migrate_fwd(apps, _schemas_editor):
+    ReportConfiguration = apps.get_model("commandcenter", "ReportConfiguration")
+    for obj in ReportConfiguration.objects.all():
+        obj.report_filename = obj.report_filename.replace("{title}", "{{title}}")
+        obj.report_filename = obj.report_filename.replace("{company}", "{{company_name}}")
+        obj.report_filename = obj.report_filename.replace("{client}", "{{client.name}}")
+        obj.report_filename = obj.report_filename.replace("{date}", "{{now|format_datetime}}")
+        obj.report_filename = obj.report_filename.replace("{assessment_type}", "{{project.project_type}}")
+        obj.report_filename = re.sub(r"(?<!{)\{([^\{}]+)\}", r'{{now|format_datetime:"\1"}}', obj.report_filename)
+        obj.save()
+
+def migrate_back(apps, _schemas_editor):
+    ReportConfiguration = apps.get_model("commandcenter", "ReportConfiguration")
+    for obj in ReportConfiguration.objects.all():
+        obj.report_filename = obj.report_filename.replace("{{title}}", "{title}")
+        obj.report_filename = obj.report_filename.replace("{{company_name}}", "{company}")
+        obj.report_filename = obj.report_filename.replace("{{client.name}}", "{client}")
+        obj.report_filename = obj.report_filename.replace("{{now|format_datetime}}", "{date}")
+        obj.report_filename = obj.report_filename.replace("{{project.project_type}}", "{assessment_type}")
+        obj.report_filename = re.sub(r'\{\{\s*now\|format_datetime:"([^"]*)"\s*\}\}', r'{\1}', obj.report_filename)
+        obj.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('commandcenter', '0024_extrafieldspec_description'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reportconfiguration',
+            name='report_filename',
+            field=models.CharField(default='{{now|format_datetime("Y-m-d_His")}} {{company.name}} - {{client.name}} {{project.project_type}} Report', help_text='Jinja2 template for report filenames. All template variables are available, plus {{now}} and {{company_name}}.', max_length=255, verbose_name='Default Name for Report Downloads'),
+        ),
+        migrations.RunPython(migrate_fwd, migrate_back)
+    ]

--- a/ghostwriter/commandcenter/models.py
+++ b/ghostwriter/commandcenter/models.py
@@ -108,8 +108,8 @@ class ReportConfiguration(SingletonModel):
     report_filename = models.CharField(
         "Default Name for Report Downloads",
         max_length=255,
-        default="{Y-m-d}_{His} {company} - {client} {assessment_type} Report",
-        help_text="Name of the report file when downloaded that can include the following variables: title, date, company, client, assessment_type, and date format string values",
+        default='{{now|format_datetime("Y-m-d_His")}} {{company.name}} - {{client.name}} {{project.project_type}} Report',
+        help_text="Jinja2 template for report filenames. All template variables are available, plus {{now}} and {{company_name}}.",
     )
     title_case_captions = models.BooleanField(
         "Title Case Captions",

--- a/ghostwriter/modules/reportwriter/jinja_funcs.py
+++ b/ghostwriter/modules/reportwriter/jinja_funcs.py
@@ -2,7 +2,7 @@
 Jinja filters that ghostwriter exposes
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import html
 import logging
 import re
@@ -141,7 +141,7 @@ def add_days(date, days):
         raise InvalidFilterValue(f'Invalid integer ("{days}") passed into the `add_days()` filter') from e
 
     try:
-        date_obj = parse_datetime(date)
+        date_obj = date if isinstance(date, datetime) else parse_datetime(date)
         # Loop until all days added
         if days > 0:
             while days > 0:
@@ -169,7 +169,7 @@ def add_days(date, days):
     return new_date
 
 
-def format_datetime(date, new_format):
+def format_datetime(date, new_format=None):
     """
     Change the format of a given date string.
 
@@ -178,11 +178,11 @@ def format_datetime(date, new_format):
     ``date``
         Date string to modify
     ``format_str``
-        The format of the provided date
+        The format of the provided date. If omitted, use the global setting.
     """
     try:
-        date_obj = parse_datetime(date)
-        formatted_date = dateformat(date_obj, new_format)
+        date_obj = date if isinstance(date, datetime) else parse_datetime(date)
+        formatted_date = dateformat(date_obj, new_format if new_format is not None else settings.DATE_FORMAT)
     except ParserError as e:
         logger.exception("Error parsing ``date`` as a date: %s", date)
         raise InvalidFilterValue(f'Invalid date string ("{date}") passed into the `format_datetime()` filter') from e


### PR DESCRIPTION
More flexible than the string replacements, and also exposes all of the template variables available to reporting for use in the filename as well.

Also changes some datetime related filters to work with actual datetime objects.

Resolves #350 
