### PR TITLE
Set column default for extra fields

### DIFF
--- a/ghostwriter/oplog/migrations/0015_extra_fields_db_default.py
+++ b/ghostwriter/oplog/migrations/0015_extra_fields_db_default.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oplog', '0014_merge_20231215_1939'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "ALTER TABLE oplog_oplogentry ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE oplog_oplogentry ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+    ]

--- a/ghostwriter/reporting/migrations/0049_extra_fields_db_default.py
+++ b/ghostwriter/reporting/migrations/0049_extra_fields_db_default.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('reporting', '0048_auto_20240307_1831'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "ALTER TABLE reporting_finding ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE reporting_finding ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE reporting_report ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE reporting_report ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE reporting_reportfindinglink ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE reporting_reportfindinglink ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE reporting_observation ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE reporting_observation ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE reporting_reportobservationlink ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE reporting_reportobservationlink ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+    ]

--- a/ghostwriter/rolodex/migrations/0049_extra_fields_db_default.py
+++ b/ghostwriter/rolodex/migrations/0049_extra_fields_db_default.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rolodex', '0048_merge_20240117_1537'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "ALTER TABLE rolodex_client ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE rolodex_client ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE rolodex_project ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE rolodex_project ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+    ]

--- a/ghostwriter/shepherd/migrations/0047_extra_fields_db_default.py
+++ b/ghostwriter/shepherd/migrations/0047_extra_fields_db_default.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shepherd', '0046_staticserver_extra_fields'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "ALTER TABLE shepherd_domain ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE shepherd_domain ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE shepherd_staticserver ALTER COLUMN extra_fields SET DEFAULT '{}'::jsonb;",
+            "ALTER TABLE shepherd_staticserver ALTER COLUMN extra_fields DROP DEFAULT;"
+        ),
+    ]


### PR DESCRIPTION
Should hopefully make the values optional on the graphql side. Not using ModelField.db_default since its Django 5.0+ only and we are currently using 3.2.
