### PR TITLE
Fix exception when converting rich text with paragraph alignments

### DIFF
--- a/ghostwriter/modules/reportwriter/html_to_docx.py
+++ b/ghostwriter/modules/reportwriter/html_to_docx.py
@@ -120,7 +120,7 @@ class HtmlToDocx(BaseHtmlToOOXML):
             # Top level <p>
             par = self.doc.add_paragraph(style=self.p_style)
 
-        par_classes = set(el.attrs.get("class", "").split())
+        par_classes = set(el.attrs.get("class", []))
         if "left" in par_classes:
             par.alignment = WD_ALIGN_PARAGRAPH.LEFT
         if "center" in par_classes:

--- a/ghostwriter/modules/reportwriter/html_to_pptx.py
+++ b/ghostwriter/modules/reportwriter/html_to_pptx.py
@@ -85,7 +85,7 @@ class HtmlToPptx(BaseHtmlToOOXML):
         self.text_tracking.new_block()
         par = self.shape.text_frame.add_paragraph()
 
-        par_classes = set(el.attrs.get("class", "").split())
+        par_classes = set(el.attrs.get("class", []))
         if "left" in par_classes:
             par.alignment = PP_ALIGN.LEFT
         if "center" in par_classes:

--- a/ghostwriter/reporting/tests/test_rich_text_docx.py
+++ b/ghostwriter/reporting/tests/test_rich_text_docx.py
@@ -570,3 +570,16 @@ class RichTextToDocxTests(TestCase):
             </w:tbl>
         """,
     )
+
+    test_paragraph_class = mk_test_docx(
+        "test_paragraph_class",
+        """
+        <p class="left">Paragraph with a class</p>
+        """,
+        """
+        <w:p>
+            <w:pPr><w:jc w:val="left"/></w:pPr>
+            <w:r><w:t>Paragraph with a class</w:t></w:r>
+        </w:p>
+        """
+    )


### PR DESCRIPTION
BeautifulSoup4 returns a list for the "class" attribute, but the code was expecting a string. This patch fixes the issue.

Issue reported by Ryan Stephenson on Slack.