### PR TITLE
Clear report template if it no longer matches the template

### DIFF
--- a/ghostwriter/commandcenter/models.py
+++ b/ghostwriter/commandcenter/models.py
@@ -135,6 +135,7 @@ class ReportConfiguration(SingletonModel):
         on_delete=models.SET_NULL,
         limit_choices_to={
             "doc_type__doc_type__iexact": "docx",
+            "client__isnull": True,
         },
         null=True,
         blank=True,
@@ -146,6 +147,7 @@ class ReportConfiguration(SingletonModel):
         on_delete=models.SET_NULL,
         limit_choices_to={
             "doc_type__doc_type__iexact": "pptx",
+            "client__isnull": True,
         },
         null=True,
         blank=True,
@@ -154,6 +156,18 @@ class ReportConfiguration(SingletonModel):
 
     def __str__(self):
         return "Global Report Configuration"
+
+    def clear_incorrect_template_defaults(self, template):
+        altered = False
+        if self.default_docx_template == template:
+            if template.client is not None or template.doc_type.doc_type != "docx":
+                self.default_docx_template = None
+                altered = True
+        if self.default_pptx_template == template:
+            if template.client is not None or template.doc_type.doc_type != "pptx":
+                self.default_pptx_template = None
+                altered = True
+        return altered
 
     class Meta:
         verbose_name = "Global Report Configuration"

--- a/ghostwriter/reporting/forms.py
+++ b/ghostwriter/reporting/forms.py
@@ -811,8 +811,10 @@ class ReportTemplateForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         for field in self.fields:
             self.fields[field].widget.attrs["autocomplete"] = "off"
+
         if kwargs.get("instance"):
-            self.fields["doc_type"].disabled = True
+            self.fields["client"].help_text += ". Changing this will unset this template as the global default template and the default templates on reports for other clients."
+            self.fields["doc_type"].help_text += ". Changing this will unset this template as the global default template and the default templates on reports."
 
         self.fields["document"].label = ""
         self.fields["document"].widget.attrs["class"] = "custom-file-input"

--- a/ghostwriter/reporting/templates/reporting/report_template_form.html
+++ b/ghostwriter/reporting/templates/reporting/report_template_form.html
@@ -32,6 +32,17 @@
     </script>
   {% endif %}
 
+  <!-- Global default warning -->
+  {% if object == report_configuration.default_docx_template %}
+    <div class="alert alert-warning" role="alert">
+      This template is the global default Word template. Be careful when editing.
+    </div>
+  {% elif object == report_configuration.default_pptx_template %}
+    <div class="alert alert-warning" role="alert">
+      This template is the global default PowerPoint template. Be careful when editing.
+    </div>
+  {% endif %}
+
   <!-- Form Section -->
   {% crispy form form.helper %}
 {% endblock %}

--- a/ghostwriter/reporting/views.py
+++ b/ghostwriter/reporting/views.py
@@ -1908,6 +1908,7 @@ class ReportTemplateUpdate(RoleBasedAccessControlMixin, UpdateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["cancel_link"] = reverse("reporting:templates")
+        ctx["report_configuration"] = ReportConfiguration.get_solo()
         return ctx
 
     def get_success_url(self):
@@ -1923,6 +1924,13 @@ class ReportTemplateUpdate(RoleBasedAccessControlMixin, UpdateView):
         obj.uploaded_by = self.request.user
         obj.save()
         form.save_m2m()
+
+        Report.clear_incorrect_template_defaults(self.object)
+
+        report_config = ReportConfiguration.get_solo()
+        if report_config.clear_incorrect_template_defaults(self.object):
+            report_config.save()
+
         return HttpResponseRedirect(self.get_success_url())
 
     def get_form_kwargs(self):


### PR DESCRIPTION
This patch will clear a report's default template if that template's type or client is updated in a way that no longer matches how its being used.
