### PR TITLE
Rework report export error handling, show error locations

### DIFF
--- a/ghostwriter/modules/reportwriter/base/xlsx.py
+++ b/ghostwriter/modules/reportwriter/base/xlsx.py
@@ -3,7 +3,7 @@ import io
 
 from xlsxwriter.workbook import Workbook
 
-from ghostwriter.modules.reportwriter.base.base import ExportBase
+from ghostwriter.modules.reportwriter.base.base import ExportBase, ReportExportError
 from ghostwriter.modules.reportwriter.richtext.plain_text import html_to_plain_text
 
 
@@ -34,13 +34,15 @@ class ExportXlsxBase(ExportBase):
     def extension(cls) -> str:
         return "xlsx"
 
-    def process_rich_text_xlsx(self, html, template_vars, evidences) -> str:
+    def process_rich_text_xlsx(self, name, html, template_vars, evidences) -> str:
         """
         Converts HTML from the TinyMCE rich text editor and returns a plain string
         for use in XLSX cells
         """
-        text = self.preprocess_rich_text(html, template_vars)
-        return html_to_plain_text(text, evidences)
+        return ReportExportError.map_jinja2_render_errors(
+            lambda: html_to_plain_text(self.preprocess_rich_text(html, template_vars), evidences),
+            name,
+        )
 
     def run(self) -> io.BytesIO:
         self.workbook.close()

--- a/ghostwriter/modules/reportwriter/project/docx.py
+++ b/ghostwriter/modules/reportwriter/project/docx.py
@@ -29,80 +29,82 @@ class ExportProjectDocx(ExportDocxBase, ExportProjectBase):
         """
 
         # Client
-        context["client"]["note_rt"] = base_render(context["client"]["note"])
-        context["client"]["address_rt"] = base_render(context["client"]["address"])
-        process_extra_fields(context["client"]["extra_fields"], Client, base_render)
+        context["client"]["note_rt"] = base_render(f"the note of client {context['client']['name']}", context["client"]["note"])
+        context["client"]["address_rt"] = base_render(f"the address of client {context['client']['name']}", context["client"]["address"])
+        process_extra_fields(f"client {context['client']['name']}", context["client"]["extra_fields"], Client, base_render)
 
         # Assignments
         for assignment in context["team"]:
             if isinstance(assignment, dict):
                 if assignment["note"]:
-                    assignment["note_rt"] = base_render(assignment["note"])
+                    assignment["note_rt"] = base_render(f"the note of person {assignment['name']}", assignment["note"])
 
         # Contacts
         for contact in context["client"]["contacts"]:
             if isinstance(contact, dict):
                 if contact["note"]:
-                    contact["note_rt"] = base_render(contact["note"])
+                    contact["note_rt"] = base_render(f"the note of contact {contact['name']}", contact["note"])
 
         # Objectives
         for objective in context["objectives"]:
             if isinstance(objective, dict):
                 if objective["description"]:
-                    objective["description_rt"] = base_render(objective["description"])
+                    objective["description_rt"] = base_render(f"the description of objective {objective['objective']}", objective["description"])
 
         # Scope Lists
         for scope_list in context["scope"]:
             if isinstance(scope_list, dict):
                 if scope_list["description"]:
-                    scope_list["description_rt"] = base_render(scope_list["description"])
+                    scope_list["description_rt"] = base_render(f"the description of scope {scope_list['name']}", scope_list["description"])
 
         # Targets
         for target in context["targets"]:
             if isinstance(target, dict):
                 if target["note"]:
-                    target["note_rt"] = base_render(target["note"])
+                    target["note_rt"] = base_render(f"the note of target {target['ip_address']}", target["note"])
 
         # Deconfliction Events
         for event in context["deconflictions"]:
             if isinstance(event, dict):
                 if event["description"]:
-                    event["description_rt"] = base_render(event["description"])
+                    event["description_rt"] = base_render(f"the description of deconfliction event {event['title']}", event["description"])
 
         # White Cards
         for card in context["whitecards"]:
             if isinstance(card, dict):
                 if card["description"]:
-                    card["description_rt"] = base_render(card["description"])
+                    card["description_rt"] = base_render(f"the descriptio of whitecard {card['title']}", card["description"])
 
         # Infrastructure
         for asset_type in context["infrastructure"]:
             for asset in context["infrastructure"][asset_type]:
                 if isinstance(asset, dict):
                     if asset["note"]:
-                        asset["note_rt"] = base_render(asset["note"])
+                        asset["note_rt"] = base_render(f"the note of {asset_type} {asset.get('name') or asset['domain']}",
+                                                       asset["note"])
+
         for asset in context["infrastructure"]["domains"]:
-            process_extra_fields(asset["extra_fields"], Domain, base_render)
+            process_extra_fields(f"domain {asset['domain']}", asset["extra_fields"], Domain, base_render)
         for asset in context["infrastructure"]["servers"]:
-            process_extra_fields(asset["extra_fields"], StaticServer, base_render)
+            process_extra_fields(f"server {asset['name']}", asset["extra_fields"], StaticServer, base_render)
 
         # Logs
         for log in context["logs"]:
             for entry in log["entries"]:
-                process_extra_fields(entry["extra_fields"], OplogEntry, base_render)
+                process_extra_fields(f"log entry {entry['description']} of log {log['name']}", entry["extra_fields"], OplogEntry, base_render)
 
     def run(self) -> io.BytesIO:
         context = self.data
         base_context = self.jinja_richtext_base_context()
 
-        def base_render(text):
-            return self.process_rich_text_docx(text, base_context, {})
+        def base_render(name, text):
+            return self.process_rich_text_docx(name, text, base_context, {})
 
         # Fields on Project
         ExportProjectDocx.process_projects_richtext(context, base_render, self.process_extra_fields)
 
         # Project
-        context["project"]["note_rt"] = base_render(context["project"]["note"])
-        self.process_extra_fields(context["project"]["extra_fields"], Project, base_render)
+        context["project"]["note_rt"] = base_render("project.note", context["project"]["note"])
+        self.process_extra_fields(f"project {context['project']['name']}", context["project"]["extra_fields"], Project, base_render)
 
         return super().run()

--- a/ghostwriter/modules/reportwriter/project/pptx.py
+++ b/ghostwriter/modules/reportwriter/project/pptx.py
@@ -91,6 +91,7 @@ class ProjectSlidesMixin:
 
         finding_body_shape = shapes.placeholders[1]
         self.process_rich_text_pptx(
+            "project.note",
             self.data["project"]["note"],
             slide=slide,
             shape=finding_body_shape,

--- a/ghostwriter/modules/reportwriter/report/docx.py
+++ b/ghostwriter/modules/reportwriter/report/docx.py
@@ -33,10 +33,10 @@ class ExportReportDocx(ExportDocxBase, ExportReportBase):
         base_context = self.jinja_richtext_base_context()
         base_evidences = {e["friendly_name"]: e for e in context["evidence"]}
 
-        def base_render(text):
-            return self.process_rich_text_docx(text, base_context, base_evidences)
+        def base_render(name, text):
+            return self.process_rich_text_docx(name, text, base_context, base_evidences)
 
-        self.process_extra_fields(context["extra_fields"], Report, base_render)
+        self.process_extra_fields("the report", context["extra_fields"], Report, base_render)
 
         # Findings
         for finding in context["findings"]:
@@ -45,33 +45,33 @@ class ExportReportDocx(ExportDocxBase, ExportReportBase):
             finding_context = self.jinja_richtext_finding_context(base_context, finding)
             finding_evidences = base_evidences | {e["friendly_name"]: e for e in finding["evidence"]}
 
-            def finding_render(text):
-                return self.process_rich_text_docx(text, finding_context, finding_evidences)
+            def finding_render(name, text):
+                return self.process_rich_text_docx(f"{name} of finding {finding['title']}", text, finding_context, finding_evidences)
 
-            self.process_extra_fields(finding["extra_fields"], Finding, finding_render)
+            self.process_extra_fields(f"finding {finding['title']}", finding["extra_fields"], Finding, finding_render)
 
             # Create ``RichText()`` object for a colored severity category
             finding["severity_rt"] = RichText(finding["severity"], color=finding["severity_color"])
             finding["cvss_score_rt"] = RichText(finding["cvss_score"], color=finding["severity_color"])
             finding["cvss_vector_rt"] = RichText(finding["cvss_vector"], color=finding["severity_color"])
             # Create subdocuments for each finding section
-            finding["affected_entities_rt"] = finding_render(finding["affected_entities"])
-            finding["description_rt"] = finding_render(finding["description"])
-            finding["impact_rt"] = finding_render(finding["impact"])
+            finding["affected_entities_rt"] = finding_render("the affected entities section", finding["affected_entities"])
+            finding["description_rt"] = finding_render("the description", finding["description"])
+            finding["impact_rt"] = finding_render("the impact section", finding["impact"])
 
             # Include a copy of ``mitigation`` as ``recommendation`` to match legacy context
-            mitigation_section = finding_render(finding["mitigation"])
+            mitigation_section = finding_render("the mitigation section", finding["mitigation"])
             finding["mitigation_rt"] = mitigation_section
             finding["recommendation_rt"] = mitigation_section
 
-            finding["replication_steps_rt"] = finding_render(finding["replication_steps"])
-            finding["host_detection_techniques_rt"] = finding_render(finding["host_detection_techniques"])
-            finding["network_detection_techniques_rt"] = finding_render(finding["network_detection_techniques"])
-            finding["references_rt"] = finding_render(finding["references"])
+            finding["replication_steps_rt"] = finding_render("the replication steps section", finding["replication_steps"])
+            finding["host_detection_techniques_rt"] = finding_render("the host detection techniques section", finding["host_detection_techniques"])
+            finding["network_detection_techniques_rt"] = finding_render("the network detection techniques section", finding["network_detection_techniques"])
+            finding["references_rt"] = finding_render("the references section", finding["references"])
 
         # Project
-        context["project"]["note_rt"] = base_render(context["project"]["note"])
-        self.process_extra_fields(context["project"]["extra_fields"], Project, base_render)
+        context["project"]["note_rt"] = base_render("the project note", context["project"]["note"])
+        self.process_extra_fields("the project", context["project"]["extra_fields"], Project, base_render)
 
         # Fields on Project
         ExportProjectDocx.process_projects_richtext(context, base_render, self.process_extra_fields)
@@ -79,12 +79,12 @@ class ExportReportDocx(ExportDocxBase, ExportReportBase):
         # Observations
         for observation in context["observations"]:
             if observation["description"]:
-                observation["description_rt"] = base_render(observation["description"])
-            self.process_extra_fields(observation["extra_fields"], Observation, base_render)
+                observation["description_rt"] = base_render(f"the description of observation {observation['title']}", observation["description"])
+            self.process_extra_fields(f"observation {observation['title']}", observation["extra_fields"], Observation, base_render)
 
         # Report Evidence
         # for evidence in context["evidence"]:
-        #    self.process_extra_fields(evidence["extra_fields"], Report, base_render)
+        #    self.process_extra_fields("the evidence", evidence["extra_fields"], Report, base_render)
 
     def run(self) -> io.BytesIO:
         self.process_richtext(self.data)

--- a/ghostwriter/modules/reportwriter/report/pptx.py
+++ b/ghostwriter/modules/reportwriter/report/pptx.py
@@ -95,6 +95,7 @@ class ExportReportPptx(ExportBasePptx, ExportReportBase, ProjectSlidesMixin):
             if observation.get("description", "").strip():
                 observation_context = self.jinja_richtext_base_context()
                 self.process_rich_text_pptx(
+                    f"the description of observation {observation['title']}",
                     observation["description"],
                     slide=observation_slide,
                     shape=observation_body_shape,
@@ -192,6 +193,7 @@ class ExportReportPptx(ExportBasePptx, ExportReportBase, ProjectSlidesMixin):
                 finding_context = self.jinja_richtext_finding_context(base_context, finding)
                 finding_evidences = base_evidences | {e["friendly_name"]: e for e in finding["evidence"]}
                 self.process_rich_text_pptx(
+                    f"the description of finding `{finding['title']}`",
                     finding["description"],
                     slide=finding_slide,
                     shape=finding_body_shape,

--- a/ghostwriter/modules/reportwriter/report/xlsx.py
+++ b/ghostwriter/modules/reportwriter/report/xlsx.py
@@ -86,7 +86,7 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["title"], finding_context, finding_evidences),
+                finding["title"],
                 bold_format,
             )
             col += 1
@@ -98,7 +98,7 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["severity"], finding_context, finding_evidences),
+                finding["severity"],
                 severity_format,
             )
             col += 1
@@ -108,14 +108,14 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
                 worksheet.write_string(
                     row,
                     col,
-                    self.process_rich_text_xlsx(finding["cvss_score"], finding_context, finding_evidences),
+                    str(finding["cvss_score"]) if finding["cvss_score"] is not None else "",
                     severity_format,
                 )
             col += 1
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["cvss_vector"], finding_context, finding_evidences),
+                str(finding["cvss_vector"]) if finding["cvss_vector"] is not None else "",
                 severity_format,
             )
             col += 1
@@ -125,7 +125,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
                 worksheet.write_string(
                     row,
                     col,
-                    self.process_rich_text_xlsx(finding["affected_entities"], finding_context, finding_evidences),
+                    self.process_rich_text_xlsx(
+                        f"the affected entities section of finding {finding['title']}",
+                        finding["affected_entities"],
+                        finding_context,
+                        finding_evidences
+                    ),
                     asset_format,
                 )
             else:
@@ -136,7 +141,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["description"], finding_context, finding_evidences),
+                self.process_rich_text_xlsx(
+                    f"the description of finding {finding['title']}",
+                    finding["description"],
+                    finding_context,
+                    finding_evidences
+                ),
                 wrap_format,
             )
             col += 1
@@ -145,7 +155,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["impact"], finding_context, finding_evidences),
+                self.process_rich_text_xlsx(
+                    f"the impact section of finding {finding['title']}",
+                    finding["impact"],
+                    finding_context,
+                    finding_evidences
+                ),
                 wrap_format,
             )
             col += 1
@@ -154,7 +169,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["recommendation"], finding_context, finding_evidences),
+                self.process_rich_text_xlsx(
+                    f"the recommendation section of finding {finding['title']}",
+                    finding["recommendation"],
+                    finding_context,
+                    finding_evidences
+                ),
                 wrap_format,
             )
             col += 1
@@ -163,7 +183,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["replication_steps"], finding_context, finding_evidences),
+                self.process_rich_text_xlsx(
+                    f"the replication section of finding {finding['title']}",
+                    finding["replication_steps"],
+                    finding_context,
+                    finding_evidences
+                ),
                 wrap_format,
             )
             col += 1
@@ -172,7 +197,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["host_detection_techniques"], finding_context, finding_evidences),
+                self.process_rich_text_xlsx(
+                    f"the detection section of finding {finding['title']}",
+                    finding["host_detection_techniques"],
+                    finding_context,
+                    finding_evidences
+                ),
                 wrap_format,
             )
             col += 1
@@ -180,7 +210,10 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
                 row,
                 col,
                 self.process_rich_text_xlsx(
-                    finding["network_detection_techniques"], finding_context, finding_evidences
+                    f"the network detection techniques section of finding {finding['title']}",
+                    finding["network_detection_techniques"],
+                    finding_context,
+                    finding_evidences
                 ),
                 wrap_format,
             )
@@ -190,7 +223,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding["references"], finding_context, finding_evidences),
+                self.process_rich_text_xlsx(
+                    f"the references section of finding {finding['title']}",
+                    finding["references"],
+                    finding_context,
+                    finding_evidences
+                ),
                 wrap_format,
             )
             col += 1
@@ -208,7 +246,7 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(finding_evidence_names, finding_context, finding_evidences),
+                finding_evidence_names,
                 wrap_format,
             )
             col += 1
@@ -217,7 +255,7 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             worksheet.write_string(
                 row,
                 col,
-                self.process_rich_text_xlsx(", ".join(finding["tags"]), finding_context, finding_evidences),
+                ", ".join(finding["tags"]),
                 wrap_format,
             )
             col += 1
@@ -226,7 +264,12 @@ class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
             for field_spec in findings_extra_field_specs:
                 field_value = field_spec.value_of(finding["extra_fields"])
                 if field_spec.type == "rich_text":
-                    field_value = self.process_rich_text_xlsx(field_value, finding_context, finding_evidences)
+                    field_value = self.process_rich_text_xlsx(
+                        f"the {field_spec.internal_name} extra field of finding {finding['title']}",
+                        field_value,
+                        finding_context,
+                        finding_evidences
+                    )
                 else:
                     field_value = str(field_value)
                 worksheet.write_string(row, col, field_value, wrap_format)

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2256,6 +2256,7 @@ class GenerateReportTests(TestCase):
         self.assertEqual(
             response.get("Content-Type"),
             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            repr(response) + repr([str(msg) for msg in get_messages(response.wsgi_request)]),
         )
 
     def test_view_all_uri_exists_at_desired_location(self):
@@ -2338,7 +2339,7 @@ class GenerateReportTests(TestCase):
         response = self.client_mgr.get(self.docx_uri)
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(
-            str(messages[0]), "Your selected Word template could not be found on the server – try uploading it again."
+            str(messages[0]), "Error: Template document file could not be found - try re-uploading it"
         )
 
         self.report.docx_template = good_template
@@ -2473,7 +2474,7 @@ class ReportTemplateFilterTests(TestCase):
 
     def test_regex_search(self):
         test_string = "This is a test string. It contains the word 'test'."
-        result = regex_search(test_string, "^(.*?)\.")
+        result = regex_search(test_string, r"^(.*?)\.")
         self.assertEqual(result, "This is a test string.")
 
     def test_filter_tags(self):

--- a/ghostwriter/rolodex/templates/rolodex/project_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/project_detail.html
@@ -1136,7 +1136,6 @@
         const url = projectExportSelector.attr("data-url").replace("replaceme", projectExportSelector.val());
         const a = document.createElement("a");
         a.href = url;
-        a.download = "";
         a.click();
       });
     });


### PR DESCRIPTION
Add `ReportExportError` and wrap user-facing errors in it, annotating it with the field or location of the error to help users narrow down template issues.