### PR TITLE
Fix oplog import/export links

### DIFF
--- a/ghostwriter/oplog/templates/oplog/oplog_detail.html
+++ b/ghostwriter/oplog/templates/oplog/oplog_detail.html
@@ -25,7 +25,7 @@
             </div>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="oplog-dropdown-btn">
                 <a href="{% url 'oplog:oplog_update' oplog.id %}" class="dropdown-item icon edit-icon" >Edit Log</a>
-                <a href="javascript:void(0)" id="importNewEntries" class="dropdown-item icon upload-icon">Import Entries</a>
+                <a href="{% url "oplog:oplog_import" %}" class="dropdown-item icon upload-icon">Import Entries</a>
                 <a href="javascript:void(0)" id="exportEntries" class="dropdown-item icon export-icon">Export Entries</a>
                 <a href="{% url 'rolodex:project_detail' oplog.project.id %}" class="dropdown-item icon project-icon" >Jump to Project</a>
                 {% if request.user.is_staff or request.user.role == "manager" or request.user.role == "admin" %}
@@ -106,7 +106,11 @@
     <table id="oplogTable" class="table table-striped table-borderless table-sm scroll table-oplog">
         <thead id="oplogTableHeader">
         </thead>
-        <tbody id="oplogTableBody" oplog-id="{{ oplog.id }}">
+        <tbody id="oplogTableBody"
+            data-oplog-name="{{ oplog.name }}"
+            data-oplog-id="{{ oplog.id }}"
+            data-oplog-export-url="{% url 'oplog:oplog_export' oplog.pk %}"
+        >
         </tbody>
         <tfoot>
           <tr style="display:none" id="oplogTableNoEntries">
@@ -135,5 +139,7 @@
   </div>
 
   {{ oplog_entry_extra_fields_spec_ser|json_script:"oplog_entry_extra_fields_spec" }}
+
+
 
 {% endblock %}

--- a/ghostwriter/static/js/oplog.js
+++ b/ghostwriter/static/js/oplog.js
@@ -23,7 +23,8 @@ $(document).ready(function() {
     const oplog_entry_extra_fields_spec = JSON.parse(document.getElementById('oplog_entry_extra_fields_spec').textContent);
 
     const $table = $('#oplogTable tbody');
-    const oplog_id = parseInt($table.attr("oplog-id"));
+    const oplog_name = $table.attr("data-oplog-name");
+    const oplog_id = parseInt($table.attr("data-oplog-id"));
     const $tableHeader = $('#oplogTableHeader');
     const $checkboxList = $('#checkboxList');
     const $connectionStatus = $('#connectionStatus');
@@ -507,15 +508,10 @@ $(document).ready(function() {
 
     // Download the log as a CSV file when the user clicks the "Export Entries" menu item
     $('#exportEntries').click(function () {
-        let filename = generateDownloadName('{{ oplog.name }}-log-export-{{ id }}.csv');
-        let export_url = "{% url 'oplog:oplog_export' oplog.pk %}";
+        let filename = generateDownloadName(oplog_name + '-log-export-' + oplog_id.toString() + '.csv');
+        let export_url = $table.attr("data-oplog-export-url");
         download(export_url, filename);
     })
-
-    // Open import form page when user clicks the "Import Entries" menu item
-    $('#importNewEntries').click(function () {
-        window.open('{% url "oplog:oplog_import" %}', '_self');
-    });
 
     // Create event to filter results in real-time as search textbox is updated
     let filter_debounce_timeout_id = null;
@@ -579,8 +575,9 @@ $(document).ready(function() {
 
         if(event.ctrlKey && event.keyCode === 83) {
             event.preventDefault();
-            let filename = generateDownloadName('{{ oplog.name }}-log-export-{{ id }}.csv');
-            download(`/oplog/api/entries?export=csv&&oplog_id={{ oplog.pk }}`, filename);
+            let filename = generateDownloadName( oplog_name + '-log-export-' + oplog_id.toString() + '.csv');
+            let export_url = $table.attr("data-oplog-export-url");
+            download(export_url + oplog_id.toString(), filename);
         }
     });
 });


### PR DESCRIPTION
Moving the oplog code to the js file broke the jinja templating in some of the js code.
