### PR TITLE
Check if templated rich text fields are valid jinja2

### DIFF
--- a/ghostwriter/api/templates/token_form.html
+++ b/ghostwriter/api/templates/token_form.html
@@ -22,11 +22,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/commandcenter/models.py
+++ b/ghostwriter/commandcenter/models.py
@@ -7,6 +7,7 @@ from django import forms
 from django.db import models
 
 # 3rd Party Libraries
+from ghostwriter.modules.reportwriter.forms import JinjaRichTextField
 from timezone_field import TimeZoneField
 
 # Ghostwriter Libraries
@@ -353,7 +354,7 @@ EXTRA_FIELD_TYPES = {
     ),
     "rich_text": ExtraFieldType(
         display_name="Formatted Text",
-        form_field=lambda *args, **kwargs: forms.CharField(required=False, *args, **kwargs),
+        form_field=lambda *args, **kwargs: JinjaRichTextField(required=False, *args, **kwargs),
         form_widget=forms.widgets.Textarea,
         from_str=lambda s: s,
         empty_value=lambda: "",

--- a/ghostwriter/modules/reportwriter/forms.py
+++ b/ghostwriter/modules/reportwriter/forms.py
@@ -1,0 +1,25 @@
+
+from django import forms
+
+import jinja2
+
+from ghostwriter.modules.reportwriter import prepare_jinja2_env
+
+
+class JinjaRichTextField(forms.CharField):
+    """
+    CharField that checks its contents to see if it's a valid Jinja2 filter.
+    """
+    def __init__(self, *args, **kwargs):
+        if "widget" not in kwargs:
+            kwargs["widget"] = forms.Textarea
+        super().__init__(*args, **kwargs)
+
+    def validate(self, value: str):
+        super().validate(value)
+        env, _ = prepare_jinja2_env(debug=True)
+        try:
+            env.from_string(value)
+        except jinja2.TemplateSyntaxError as e:
+            line = value.splitlines()[e.lineno - 1]
+            raise forms.ValidationError(f"{e} at `{line}`") from e

--- a/ghostwriter/oplog/templates/oplog/oplog_form.html
+++ b/ghostwriter/oplog/templates/oplog/oplog_form.html
@@ -28,11 +28,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/oplog/templates/oplog/snippets/oplogentry_form_inner.html
+++ b/ghostwriter/oplog/templates/oplog/snippets/oplogentry_form_inner.html
@@ -5,11 +5,11 @@
     <script>
         {% for field in form %}
             {% for error in field.errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         {% endfor %}
         {% for error in form.non_field_errors %}
-            displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+            displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
         {% endfor %}
     </script>
 {% endif %}

--- a/ghostwriter/reporting/forms.py
+++ b/ghostwriter/reporting/forms.py
@@ -28,6 +28,7 @@ from ghostwriter.api.utils import get_client_list, get_project_list
 from ghostwriter.commandcenter.forms import ExtraFieldsField
 from ghostwriter.commandcenter.models import ReportConfiguration
 from ghostwriter.modules.custom_layout_object import SwitchToggle
+from ghostwriter.modules.reportwriter.forms import JinjaRichTextField
 from ghostwriter.modules.reportwriter.project.base import ExportProjectBase
 from ghostwriter.modules.reportwriter.report.base import ExportReportBase
 from ghostwriter.reporting.models import (
@@ -53,6 +54,15 @@ class FindingForm(forms.ModelForm):
     class Meta:
         model = Finding
         fields = "__all__"
+        field_classes = {
+            "description": JinjaRichTextField,
+            "impact": JinjaRichTextField,
+            "mitigation": JinjaRichTextField,
+            "replication_steps": JinjaRichTextField,
+            "host_detection_techniques": JinjaRichTextField,
+            "references": JinjaRichTextField,
+            "finding_guidance": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -369,6 +379,15 @@ class ReportFindingLinkUpdateForm(forms.ModelForm):
             "finding_guidance",
             "added_as_blank",
         )
+        field_classes = {
+            "description": JinjaRichTextField,
+            "impact": JinjaRichTextField,
+            "mitigation": JinjaRichTextField,
+            "replication_steps": JinjaRichTextField,
+            "host_detection_techniques": JinjaRichTextField,
+            "references": JinjaRichTextField,
+            "finding_guidance": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -617,6 +636,9 @@ class EvidenceForm(forms.ModelForm):
         widgets = {
             "document": forms.FileInput(attrs={"class": "form-control"}),
         }
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         self.is_modal = kwargs.pop("is_modal", None)
@@ -727,6 +749,9 @@ class FindingNoteForm(forms.ModelForm):
     class Meta:
         model = FindingNote
         fields = ("note",)
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -767,6 +792,9 @@ class LocalFindingNoteForm(forms.ModelForm):
     class Meta:
         model = LocalFindingNote
         fields = ("note",)
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1069,6 +1097,9 @@ class ObservationForm(forms.ModelForm):
     class Meta:
         model = Observation
         fields = "__all__"
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1121,6 +1152,9 @@ class ReportObservationLinkUpdateForm(forms.ModelForm):
             "position",
             "added_as_blank",
         )
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ghostwriter/reporting/templates/reporting/finding_form.html
+++ b/ghostwriter/reporting/templates/reporting/finding_form.html
@@ -42,11 +42,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/reporting/templates/reporting/local_edit.html
+++ b/ghostwriter/reporting/templates/reporting/local_edit.html
@@ -170,11 +170,11 @@
     <script>
       {% for field in form %}
         {% for error in field.errors %}
-          displayToastTop({type: 'error', string: '{{ error }}', context: 'form'});
+          displayToastTop({type: 'error', string: '{{ error|escapejs }}', context: 'form'});
         {% endfor %}
       {% endfor %}
       {% for error in form.non_field_errors %}
-        displayToastTop({type: 'error', string: '{{ error }}', context: 'form'});
+        displayToastTop({type: 'error', string: '{{ error|escapejs }}', context: 'form'});
       {% endfor %}
     </script>
   {% endif %}

--- a/ghostwriter/reporting/templates/reporting/observation_form.html
+++ b/ghostwriter/reporting/templates/reporting/observation_form.html
@@ -20,11 +20,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/reporting/templates/reporting/report_extra_field_edit.html
+++ b/ghostwriter/reporting/templates/reporting/report_extra_field_edit.html
@@ -25,11 +25,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/reporting/templates/reporting/report_form.html
+++ b/ghostwriter/reporting/templates/reporting/report_form.html
@@ -30,11 +30,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/rolodex/forms_client.py
+++ b/ghostwriter/rolodex/forms_client.py
@@ -26,6 +26,7 @@ from ghostwriter.commandcenter.forms import ExtraFieldsField
 # Ghostwriter Libraries
 from ghostwriter.commandcenter.models import GeneralConfiguration
 from ghostwriter.modules.custom_layout_object import CustomTab, Formset
+from ghostwriter.modules.reportwriter.forms import JinjaRichTextField
 from ghostwriter.rolodex.models import Client, ClientContact, ClientNote
 
 # Number of "extra" formsets created by default
@@ -107,6 +108,9 @@ class ClientContactForm(forms.ModelForm):
     class Meta:
         model = ClientContact
         exclude = ("client",)
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -209,6 +213,10 @@ class ClientForm(forms.ModelForm):
     class Meta:
         model = Client
         fields = "__all__"
+        field_classes = {
+            "note": JinjaRichTextField,
+            "address": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ghostwriter/rolodex/forms_project.py
+++ b/ghostwriter/rolodex/forms_project.py
@@ -31,6 +31,7 @@ from crispy_forms.layout import (
 from ghostwriter.commandcenter.forms import ExtraFieldsField
 from ghostwriter.commandcenter.models import GeneralConfiguration
 from ghostwriter.modules.custom_layout_object import CustomTab, Formset, SwitchToggle
+from ghostwriter.modules.reportwriter.forms import JinjaRichTextField
 from ghostwriter.rolodex.models import (
     Deconfliction,
     Project,
@@ -501,6 +502,9 @@ class ProjectAssignmentForm(forms.ModelForm):
                 format="%Y-%m-%d",
             ),
         }
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -618,6 +622,9 @@ class ProjectObjectiveForm(forms.ModelForm):
                 format="%Y-%m-%d",
             ),
         }
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -723,6 +730,9 @@ class ProjectScopeForm(forms.ModelForm):
     class Meta:
         model = ProjectScope
         fields = ("name", "scope", "description", "disallowed", "requires_caution")
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -818,6 +828,9 @@ class ProjectTargetForm(forms.ModelForm):
             "hostname",
             "note",
         )
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -894,6 +907,9 @@ class WhiteCardForm(forms.ModelForm):
     class Meta:
         model = WhiteCard
         exclude = ("project",)
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1150,6 +1166,9 @@ class ProjectForm(forms.ModelForm):
                 format="%Y-%m-%d",
             ),
         }
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1319,6 +1338,9 @@ class DeconflictionForm(forms.ModelForm):
             "created_at",
             "project",
         )
+        field_classes = {
+            "description": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ghostwriter/rolodex/templates/rolodex/deconfliction_form.html
+++ b/ghostwriter/rolodex/templates/rolodex/deconfliction_form.html
@@ -35,11 +35,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/shepherd/forms.py
+++ b/ghostwriter/shepherd/forms.py
@@ -17,6 +17,7 @@ from crispy_forms.layout import HTML, ButtonHolder, Column, Div, Layout, Row, Su
 from ghostwriter.api.utils import get_client_list
 from ghostwriter.commandcenter.forms import ExtraFieldsField
 from ghostwriter.modules.custom_layout_object import SwitchToggle
+from ghostwriter.modules.reportwriter.forms import JinjaRichTextField
 from ghostwriter.rolodex.models import Project
 from ghostwriter.shepherd.models import (
     Domain,
@@ -172,6 +173,9 @@ class DomainForm(forms.ModelForm):
             "expiration": forms.DateInput(
                 format="%Y-%m-%d",
             ),
+        }
+        field_classes = {
+            "note": JinjaRichTextField,
         }
 
     def __init__(self, *args, **kwargs):

--- a/ghostwriter/shepherd/forms_server.py
+++ b/ghostwriter/shepherd/forms_server.py
@@ -27,6 +27,7 @@ from crispy_forms.layout import (
 from ghostwriter.api.utils import get_client_list
 from ghostwriter.commandcenter.forms import ExtraFieldsField
 from ghostwriter.modules.custom_layout_object import CustomTab, Formset, SwitchToggle
+from ghostwriter.modules.reportwriter.forms import JinjaRichTextField
 from ghostwriter.rolodex.models import Project
 from ghostwriter.shepherd.models import (
     AuxServerAddress,
@@ -201,6 +202,9 @@ class ServerForm(forms.ModelForm):
     class Meta:
         model = StaticServer
         exclude = ("last_used_by",)
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -301,6 +305,9 @@ class TransientServerForm(forms.ModelForm):
     class Meta:
         model = TransientServer
         exclude = ("project",)
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -376,6 +383,9 @@ class ServerNoteForm(forms.ModelForm):
     class Meta:
         model = ServerNote
         fields = ("note",)
+        field_classes = {
+            "note": JinjaRichTextField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ghostwriter/shepherd/templates/shepherd/burn.html
+++ b/ghostwriter/shepherd/templates/shepherd/burn.html
@@ -11,11 +11,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/shepherd/templates/shepherd/connect_form.html
+++ b/ghostwriter/shepherd/templates/shepherd/connect_form.html
@@ -12,11 +12,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/shepherd/templates/shepherd/domain_form.html
+++ b/ghostwriter/shepherd/templates/shepherd/domain_form.html
@@ -22,11 +22,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/shepherd/templates/shepherd/server_checkout.html
+++ b/ghostwriter/shepherd/templates/shepherd/server_checkout.html
@@ -20,11 +20,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/shepherd/templates/shepherd/server_form.html
+++ b/ghostwriter/shepherd/templates/shepherd/server_form.html
@@ -22,11 +22,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/shepherd/templates/shepherd/vps_form.html
+++ b/ghostwriter/shepherd/templates/shepherd/vps_form.html
@@ -11,11 +11,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}

--- a/ghostwriter/templates/base_generic.html
+++ b/ghostwriter/templates/base_generic.html
@@ -579,15 +579,15 @@
   {% for message in messages %}
     {% if 'no-toast' not in message.tags %}
       {% if message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
-        displayToastTop({type: 'success', string: '{{ message }}'});
+        displayToastTop({type: 'success', string: '{{ message|escapejs }}'});
       {% elif message.level == DEFAULT_MESSAGE_LEVELS.WARNING %}
-        displayToastTop({type: 'warning', string: '{{ message }}'});
+        displayToastTop({type: 'warning', string: '{{ message|escapejs }}'});
       {% elif message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
-        displayToastTop({type: 'error', string: '{{ message }}'});
+        displayToastTop({type: 'error', string: '{{ message|escapejs }}'});
       {% elif message.level == DEFAULT_MESSAGE_LEVELS.INFO %}
-        displayToastTop({type: 'info', string: '{{ message }}'});
+        displayToastTop({type: 'info', string: '{{ message|escapejs }}'});
       {% elif message.level == DEFAULT_MESSAGE_LEVELS.DEBUG %}
-        displayToastTop({type: 'info', string: '{{ message }}'});
+        displayToastTop({type: 'info', string: '{{ message|escapejs }}'});
       {% endif %}
     {% endif %}
   {% endfor %}

--- a/ghostwriter/templates/formset.html
+++ b/ghostwriter/templates/formset.html
@@ -6,11 +6,11 @@
             {% for form in formset %}
                 {% for field in form %}
                     {% for error in field.errors %}
-                        displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                        displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                     {% endfor %}
                 {% endfor %}
                 {% for error in form.non_field_errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
         </script>

--- a/ghostwriter/templates/note_form.html
+++ b/ghostwriter/templates/note_form.html
@@ -11,11 +11,11 @@
         <script>
             {% for field in form %}
                 {% for error in field.errors %}
-                    displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                    displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
                 {% endfor %}
             {% endfor %}
             {% for error in form.non_field_errors %}
-                displayToastTop({type:'error', string:'{{ error }}', context:'form'});
+                displayToastTop({type:'error', string:'{{ error|escapejs }}', context:'form'});
             {% endfor %}
         </script>
     {% endif %}


### PR DESCRIPTION
Since rich text fields are now processed with jinja2, this patch checks them when saved to ensure they are valid jinja2 templates, and raises a validation error if they aren't.

Also fixes an issue with the error toasts that appear when attempting to save a field that failed validation.