### PR TITLE
Fix `{{.evidence}}` references not passing validation

### DIFF
--- a/ghostwriter/modules/reportwriter/base/__init__.py
+++ b/ghostwriter/modules/reportwriter/base/__init__.py
@@ -1,0 +1,32 @@
+
+import re
+import jinja2
+
+from ghostwriter.modules.reportwriter import jinja_funcs
+
+
+def rich_text_template(env: jinja2.Environment, text: str) -> jinja2.Template:
+    """
+    Converts rich text `text` to a Jinja template. This does some additional Ghostwriter-specific
+    processing.
+    """
+    # Replace old `{{.item}}`` syntax with jinja templates or elements to replace
+    def replace_old_tag(match: re.Match):
+        contents = match.group(1).strip()
+        # These will be swapped out when parsing the HTML
+        if contents.startswith("ref "):
+            return jinja_funcs.ref(contents[4:].strip())
+        elif contents == "caption":
+            return jinja_funcs.caption("")
+        elif contents.startswith("caption "):
+            return jinja_funcs.caption(contents[8:].strip())
+        return "{{ _old_dot_vars[" + repr(contents.strip()) + "]}}"
+
+    text_old_dot_subbed = re.sub(r"\{\{\.(.*?)\}\}", replace_old_tag, text)
+
+    text_pagebrea_subbed = text_old_dot_subbed.replace(
+        "<p><!-- pagebreak --></p>", '<br data-gw-pagebreak="true" />'
+    )
+
+    # Compile
+    return env.from_string(text_pagebrea_subbed)

--- a/ghostwriter/modules/reportwriter/forms.py
+++ b/ghostwriter/modules/reportwriter/forms.py
@@ -4,6 +4,7 @@ from django import forms
 import jinja2
 
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
+from ghostwriter.modules.reportwriter.base import rich_text_template
 
 
 class JinjaRichTextField(forms.CharField):
@@ -19,7 +20,7 @@ class JinjaRichTextField(forms.CharField):
         super().validate(value)
         env, _ = prepare_jinja2_env(debug=True)
         try:
-            env.from_string(value)
+            rich_text_template(env, value)
         except jinja2.TemplateSyntaxError as e:
             line = value.splitlines()[e.lineno - 1]
             raise forms.ValidationError(f"{e} at `{line}`") from e


### PR DESCRIPTION
Follow up fix to #431 