### PR TITLE
Update oplog_import.html

### DIFF
--- a/ghostwriter/oplog/templates/oplog/oplog_import.html
+++ b/ghostwriter/oplog/templates/oplog/oplog_import.html
@@ -61,7 +61,7 @@
     <div class="row">
       <div class="alert alert-warning offset-md-2 col-md-8 mt-2" role="alert">
         <h4 class="alert-heading">Note on Timestamps</h4>
-        <p>Your <em>start_date</em> and <em>end_date</em> values must be in the <em>YYYY-MM-DD HH:MM:SS</em> format.</p>
+        <p>Your <em>start_date</em> and <em>end_date</em> values must be in the <em>YYYY-MM-DD HH:MM:SS+00:00</em> format.</p>
         <p>The timestamps should match what you get when exporting a log.</p>
       </div>
     </div>


### PR DESCRIPTION
Indicate that timezone offset is required.

### Identify the Bug
https://github.com/GhostManager/Ghostwriter/issues/433

### Description of the Change
Change YYYY-MM-DD HH:MM:SS to YYYY-MM-DD HH:MM:SS+00:00.

This is a small change that aims to increase clarity of the required format for start_date and end_date fields when uploading custom Operation Logs.  Using the YYYY-MM-DD HH:MM:SS format results in the bug identified above.  Using the YYYY-MM-DD HH:MM:SS+00:00 format fixes the bug. 

### Alternate Designs
Could use a general plus/minus HH:MM indicator of timezone offset.

### Possible Drawbacks

N/A

### Verification Process

It is a 6 character addition to an existing line in the ghostwriter/oplog/templates/oplog/oplog_import.html file.

### Release Notes

- Improved clarity of required OpLog timestamp format.
