### PR TITLE
Add support for looping lists and tables in rich text jinja

### DIFF
--- a/ghostwriter/modules/reportwriter/base/__init__.py
+++ b/ghostwriter/modules/reportwriter/base/__init__.py
@@ -1,8 +1,75 @@
 
 import re
+import bs4
 import jinja2
 
+from ghostwriter.modules.exceptions import InvalidFilterValue
 from ghostwriter.modules.reportwriter import jinja_funcs
+
+
+class ReportExportError(Exception):
+    """
+    User-facing error related to report generation
+    """
+    def __init__(self, display_text: str, location: str | None = None):
+        self.display_text = display_text
+        self.location = location
+
+    def __str__(self) -> str:
+        return self.display_text
+
+    def at_error(self) -> str:
+        """
+        If the error has a `location` field, returns a string `" at {the_location}"`, else returns the empty string.
+        """
+        if self.location is None:
+            return ""
+        return f" at {self.location}"
+
+    @classmethod
+    def map_jinja2_render_errors(cls, callback, location: str | None = None):
+        """
+        Runs `callback` with no arguments, catching any Jinja-related exceptions and translating them to `ReportSyntaxError`s
+        while noting the `location`.
+        """
+        try:
+            return callback()
+        except jinja2.TemplateSyntaxError as err:
+            raise ReportExportError(f"Template syntax error: {err}", location) from err
+        except jinja2.UndefinedError as err:
+            raise ReportExportError(f"Template syntax error: {err}", location) from err
+        except InvalidFilterValue as err:
+            raise ReportExportError(f"Invalid filter value: {err.message}", location) from err
+        except jinja2.TemplateError as err:
+            raise ReportExportError(f"Template error: {err}", location) from err
+        except ZeroDivisionError as err:
+            raise ReportExportError("Template attempted to divide by zero", location) from err
+        except TypeError as err:
+            raise ReportExportError(f"Invalid template operation: {err}", location) from err
+
+
+def _process_prefix(input_str: str, soup: bs4.BeautifulSoup, prefix: str):
+    """
+    Converts text nodes of the form `{%prefix someop %}` and replaces its parent `prefix` tag with `{% someop %}`
+    in the passed-in soup.
+    """
+
+    regex = re.compile(r"^\s*\{%\s*" + re.escape(prefix) + r"\b(.*)%\}\s*$")
+    # Store in list since we mutate the nodes
+    matching_strings = list(soup.find_all(string=regex))
+    for node in matching_strings:
+        # Find parent to strip out
+        parent_tag = None
+        for parent in node.parents:
+            if parent.name == prefix:
+                parent_tag = parent
+                break
+        if parent_tag is None:
+            line = input_str.splitlines()[node.parent.sourceline - 1]
+            raise ReportExportError(f"Jinja tag prefixed with '{prefix}' was not a descendant of a {prefix} tag, in line `{line}`")
+
+        capture = regex.search(node)
+        parent_tag.replace_with("{%" + capture.group(1) + "%}")
 
 
 def rich_text_template(env: jinja2.Environment, text: str) -> jinja2.Template:
@@ -22,11 +89,20 @@ def rich_text_template(env: jinja2.Environment, text: str) -> jinja2.Template:
             return jinja_funcs.caption(contents[8:].strip())
         return "{{ _old_dot_vars[" + repr(contents.strip()) + "]}}"
 
-    text_old_dot_subbed = re.sub(r"\{\{\.(.*?)\}\}", replace_old_tag, text)
+    text = re.sub(r"\{\{\.(.*?)\}\}", replace_old_tag, text)
 
-    text_pagebrea_subbed = text_old_dot_subbed.replace(
+    # Replace page breaks with something that the parser can easily pick up
+    text = text.replace(
         "<p><!-- pagebreak --></p>", '<br data-gw-pagebreak="true" />'
     )
 
+    # Replace `{%li foreach %}`-esque prefixes. This is similar to what python-docx-template does.
+    soup = bs4.BeautifulSoup(text, "html.parser")
+    _process_prefix(text, soup, "li")
+    _process_prefix(text, soup, "p")
+    _process_prefix(text, soup, "tr")
+    _process_prefix(text, soup, "td")
+    text = str(soup)
+
     # Compile
-    return env.from_string(text_pagebrea_subbed)
+    return env.from_string(text)

--- a/ghostwriter/modules/reportwriter/base/base.py
+++ b/ghostwriter/modules/reportwriter/base/base.py
@@ -10,9 +10,8 @@ import jinja2
 from django.db.models import Model
 
 from ghostwriter.commandcenter.models import CompanyInformation, ExtraFieldSpec
-from ghostwriter.modules.exceptions import InvalidFilterValue
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
-from ghostwriter.modules.reportwriter.base import rich_text_template
+from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
 
 
 class ExportBase:
@@ -156,44 +155,3 @@ def _replace_filename_chars(name):
     """Remove illegal characters from the report name."""
     name = name.replace("–", "-")
     return re.sub(r"[<>:;\"'/\\|?*.,{}\[\]]", "", name)
-
-
-class ReportExportError(Exception):
-    """
-    User-facing error related to report generation
-    """
-    def __init__(self, display_text: str, location: str | None = None):
-        self.display_text = display_text
-        self.location = location
-
-    def __str__(self) -> str:
-        return self.display_text
-
-    def at_error(self) -> str:
-        """
-        If the error has a `location` field, returns a string `" at {the_location}"`, else returns the empty string.
-        """
-        if self.location is None:
-            return ""
-        return f" at {self.location}"
-
-    @classmethod
-    def map_jinja2_render_errors(cls, callback, location: str | None = None):
-        """
-        Runs `callback` with no arguments, catching any Jinja-related exceptions and translating them to `ReportSyntaxError`s
-        while noting the `location`.
-        """
-        try:
-            return callback()
-        except jinja2.TemplateSyntaxError as err:
-            raise ReportExportError(f"Template syntax error: {err}", location) from err
-        except jinja2.UndefinedError as err:
-            raise ReportExportError(f"Template syntax error: {err}", location) from err
-        except InvalidFilterValue as err:
-            raise ReportExportError(f"Invalid filter value: {err.message}", location) from err
-        except jinja2.TemplateError as err:
-            raise ReportExportError(f"Template error: {err}", location) from err
-        except ZeroDivisionError as err:
-            raise ReportExportError("Template attempted to divide by zero", location) from err
-        except TypeError as err:
-            raise ReportExportError(f"Invalid template operation: {err}", location) from err

--- a/ghostwriter/modules/reportwriter/base/docx.py
+++ b/ghostwriter/modules/reportwriter/base/docx.py
@@ -12,7 +12,8 @@ from docx.shared import Inches, Pt
 from docx.image.exceptions import UnrecognizedImageError
 
 from ghostwriter.commandcenter.models import CompanyInformation, ReportConfiguration
-from ghostwriter.modules.reportwriter.base.base import ExportBase, ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base.base import ExportBase
 from ghostwriter.modules.reportwriter.richtext.docx import HtmlToDocxWithEvidence
 
 logger = logging.getLogger(__name__)

--- a/ghostwriter/modules/reportwriter/base/pptx.py
+++ b/ghostwriter/modules/reportwriter/base/pptx.py
@@ -16,7 +16,8 @@ from pptx.oxml.ns import nsdecls
 from pptx.enum.text import MSO_AUTO_SIZE
 
 from ghostwriter.commandcenter.models import CompanyInformation
-from ghostwriter.modules.reportwriter.base.base import ExportBase, ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base.base import ExportBase
 from ghostwriter.modules.reportwriter.richtext.pptx import HtmlToPptxWithEvidence
 
 logger = logging.getLogger(__name__)

--- a/ghostwriter/modules/reportwriter/base/xlsx.py
+++ b/ghostwriter/modules/reportwriter/base/xlsx.py
@@ -3,7 +3,8 @@ import io
 
 from xlsxwriter.workbook import Workbook
 
-from ghostwriter.modules.reportwriter.base.base import ExportBase, ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base.base import ExportBase
 from ghostwriter.modules.reportwriter.richtext.plain_text import html_to_plain_text
 
 

--- a/ghostwriter/modules/reportwriter/forms.py
+++ b/ghostwriter/modules/reportwriter/forms.py
@@ -4,7 +4,7 @@ from django import forms
 import jinja2
 
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
-from ghostwriter.modules.reportwriter.base import rich_text_template
+from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
 
 
 class JinjaRichTextField(forms.CharField):
@@ -24,3 +24,5 @@ class JinjaRichTextField(forms.CharField):
         except jinja2.TemplateSyntaxError as e:
             line = value.splitlines()[e.lineno - 1]
             raise forms.ValidationError(f"{e} at `{line}`") from e
+        except ReportExportError as e:
+            raise forms.ValidationError(str(e)) from e

--- a/ghostwriter/reporting/tests/test_rich_text_templating.py
+++ b/ghostwriter/reporting/tests/test_rich_text_templating.py
@@ -1,0 +1,30 @@
+
+from django.test import TestCase
+
+from ghostwriter.modules.reportwriter import prepare_jinja2_env
+from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
+
+
+class RichTextTemplatingTests(TestCase):
+    maxDiff = None
+
+    def test_list(self):
+        env, _ = prepare_jinja2_env(debug=True)
+        template = rich_text_template(env, "<ol><li>{%li for i in thelist %}</li><li>{{i}}</li><li>{%li endfor %}</li></ol>")
+        out = template.render({
+            "thelist": ["foo", "bar", "baz"]
+        })
+        self.assertEqual(out, "<ol><li>foo</li><li>bar</li><li>baz</li></ol>")
+
+    def test_table(self):
+        env, _ = prepare_jinja2_env(debug=True)
+        template = rich_text_template(env, "<table><tr><td>{%tr for row in thelist%}</td><td></td></tr><tr><td>{{row[0]}}</td><td>{{row[1]}}</td></tr><tr><td>{%tr endfor %}</td><td></td></tr></table>")
+        out = template.render({
+            "thelist": [["foo", 1], ["bar", 2], ["baz", 3]]
+        })
+        self.assertEqual(out, "<table><tr><td>foo</td><td>1</td></tr><tr><td>bar</td><td>2</td></tr><tr><td>baz</td><td>3</td></tr></table>")
+
+    def test_prefix_not_nested(self):
+        env, _ = prepare_jinja2_env(debug=True)
+        with self.assertRaisesMessage(ReportExportError, "Jinja tag prefixed with 'li' was not a descendant of a li tag"):
+            rich_text_template(env, "<ol>{%li for i in thelist %}<li>{{i}}</li><li>{%li endfor %}</li></ol>")

--- a/ghostwriter/reporting/views.py
+++ b/ghostwriter/reporting/views.py
@@ -54,7 +54,7 @@ from ghostwriter.commandcenter.forms import SingleExtraFieldForm
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
 from ghostwriter.modules.exceptions import MissingTemplate
 from ghostwriter.modules.model_utils import to_dict
-from ghostwriter.modules.reportwriter.base.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportError
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.modules.reportwriter.report.docx import ExportReportDocx
 from ghostwriter.modules.reportwriter.report.pptx import ExportReportPptx

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -32,7 +32,7 @@ from ghostwriter.api.utils import (
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
 from ghostwriter.modules import codenames
 from ghostwriter.modules.model_utils import to_dict
-from ghostwriter.modules.reportwriter.base.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportError
 from ghostwriter.modules.reportwriter.project.json import ExportProjectJson
 from ghostwriter.reporting.models import ReportTemplate
 from ghostwriter.rolodex.filters import ClientFilter, ProjectFilter


### PR DESCRIPTION
Similar to docx templates, you can now use `{%li for ...}`, `{%tr for ...}`, `{%p for ...}` and other variations to repeat sections for lists, tables, and paragraphs. This works by finding the ancestor of the jinja tag that matches the prefix, and replacing it and its contents with the jinja tag without the prefix.
