### PR TITLE
Fix using severity_rt in rich text fields

### DIFF
--- a/ghostwriter/modules/reportwriter/base/__init__.py
+++ b/ghostwriter/modules/reportwriter/base/__init__.py
@@ -1,10 +1,13 @@
 
+import logging
 import re
 import bs4
 import jinja2
 
 from ghostwriter.modules.exceptions import InvalidFilterValue
 from ghostwriter.modules.reportwriter import jinja_funcs
+
+logger = logging.getLogger(__name__)
 
 
 class ReportExportError(Exception):
@@ -45,6 +48,7 @@ class ReportExportError(Exception):
         except ZeroDivisionError as err:
             raise ReportExportError("Template attempted to divide by zero", location) from err
         except TypeError as err:
+            logger.exception("Template TypeError, may be a bug or an issue with the template")
             raise ReportExportError(f"Invalid template operation: {err}", location) from err
 
 

--- a/ghostwriter/modules/reportwriter/base/html_rich_text.py
+++ b/ghostwriter/modules/reportwriter/base/html_rich_text.py
@@ -1,0 +1,77 @@
+
+from typing import Any
+import jinja2
+from markupsafe import Markup
+
+from ghostwriter.modules.reportwriter.base import ReportExportError
+
+
+def deep_copy_with_copiers(value, typ_copiers):
+    """
+    Deep copies a value with custom handlers.
+
+    `class_copiers` is a dict with class keys and
+    """
+    typ = type(value)
+    if typ in typ_copiers:
+        # A more advanced implementaiton would respect subclasses, but that's not needed (yet)
+        return typ_copiers[typ](value)
+    if isinstance(value, dict):
+        return {k: deep_copy_with_copiers(v, typ_copiers) for k, v in value.items()}
+    if isinstance(value, list):
+        return [deep_copy_with_copiers(v, typ_copiers) for v in value]
+    return value
+
+
+class LazilyRenderedTemplate:
+    """
+    Renders a template lazily
+    """
+    template: jinja2.Template
+    context: dict
+    location: str | None
+    rendered: str | None
+    rendering: bool
+
+    def __init__(self, template: jinja2.Template, location: str | None, context: dict):
+        self.template = template
+        self.context = context
+        self.location = location
+        self.rendered = None
+        self.rendering = False
+
+    def render_html(self):
+        """
+        Will throw a `ReportExportError` if the template attempted to render itself while it was
+        rendering (i.e. infinite recursion).
+        """
+        if self.rendered is None:
+            if self.rendering:
+                raise ReportExportError(f"Circular reference to {self.location} (ensure rich text fields are not referencing each other)")
+            self.rendering = True
+            self.rendered = Markup(
+                ReportExportError.map_jinja2_render_errors(
+                    lambda: self.template.render(self.context),
+                    self.location,
+                )
+            )
+            self.rendering = False
+        return self.rendered
+
+    def __html__(self):
+        return self.render_html()
+
+
+class HtmlAndRich:
+    """
+    Object containing some rich-text HTML and an exporter-specific rich-text object.
+    """
+    html: Markup
+    rich: Any
+
+    def __init__(self, html: Markup, rich: Any):
+        self.html = html
+        self.rich = rich
+
+    def __html__(self):
+        return self.html

--- a/ghostwriter/modules/reportwriter/base/pptx.py
+++ b/ghostwriter/modules/reportwriter/base/pptx.py
@@ -17,7 +17,8 @@ from pptx.enum.text import MSO_AUTO_SIZE
 
 from ghostwriter.commandcenter.models import CompanyInformation
 from ghostwriter.modules.reportwriter.base import ReportExportError
-from ghostwriter.modules.reportwriter.base.base import ExportBase, LazilyRenderedTemplate
+from ghostwriter.modules.reportwriter.base.base import ExportBase
+from ghostwriter.modules.reportwriter.base.html_rich_text import LazilyRenderedTemplate
 from ghostwriter.modules.reportwriter.richtext.pptx import HtmlToPptxWithEvidence
 
 logger = logging.getLogger(__name__)
@@ -68,19 +69,19 @@ class ExportBasePptx(ExportBase):
 
         self.company_config = CompanyInformation.get_solo()
 
-    def render_rich_text_pptx(self, template: LazilyRenderedTemplate, slide, shape):
+    def render_rich_text_pptx(self, rich_text: LazilyRenderedTemplate, slide, shape):
         """
         Renders a `LazilyRenderedTemplate`, converting the HTML from the TinyMCE rich text editor and inserting it into the passed in shape and slide.
         Converts HTML from the TinyMCE rich text editor and inserts it into the passed in slide and shape
         """
         ReportExportError.map_jinja2_render_errors(
             lambda: HtmlToPptxWithEvidence.run(
-                template.render(),
+                rich_text.render_html(),
                 slide=slide,
                 shape=shape,
                 evidences=self.evidences_by_id,
             ),
-            template.location
+            getattr(rich_text, "location", None)
         )
 
     def process_footers(self):

--- a/ghostwriter/modules/reportwriter/base/xlsx.py
+++ b/ghostwriter/modules/reportwriter/base/xlsx.py
@@ -4,7 +4,8 @@ import io
 from xlsxwriter.workbook import Workbook
 
 from ghostwriter.modules.reportwriter.base import ReportExportError
-from ghostwriter.modules.reportwriter.base.base import ExportBase, LazilyRenderedTemplate
+from ghostwriter.modules.reportwriter.base.base import ExportBase
+from ghostwriter.modules.reportwriter.base.html_rich_text import LazilyRenderedTemplate
 from ghostwriter.modules.reportwriter.richtext.plain_text import html_to_plain_text
 
 
@@ -35,17 +36,17 @@ class ExportXlsxBase(ExportBase):
     def extension(cls) -> str:
         return "xlsx"
 
-    def render_rich_text_xlsx(self, template: LazilyRenderedTemplate) -> str:
+    def render_rich_text_xlsx(self, rich_text: LazilyRenderedTemplate) -> str:
         """
         Renders a `LazilyRenderedTemplate`, converting the HTML from the TinyMCE rich text editor to a plain text string
         for use in XLSX cells
         """
         return ReportExportError.map_jinja2_render_errors(
             lambda: html_to_plain_text(
-                template.render(),
-                {}  # TODO: fix evidences
+                rich_text.render_html(),
+                self.evidences_by_id,
             ),
-            template.location,
+            getattr(rich_text, "location", None),
         )
 
     def run(self) -> io.BytesIO:

--- a/ghostwriter/modules/reportwriter/report/base.py
+++ b/ghostwriter/modules/reportwriter/report/base.py
@@ -1,12 +1,16 @@
 
 from collections import ChainMap
 import copy
+import html
+
+from markupsafe import Markup
 
 from ghostwriter.commandcenter.models import ExtraFieldSpec
 from ghostwriter.modules.custom_serializers import ReportDataSerializer
 from ghostwriter.modules.linting_utils import LINTER_CONTEXT
 from ghostwriter.modules.reportwriter import jinja_funcs
 from ghostwriter.modules.reportwriter.base.base import ExportBase
+from ghostwriter.modules.reportwriter.base.html_rich_text import HtmlAndRich
 from ghostwriter.modules.reportwriter.project.base import ExportProjectBase
 from ghostwriter.oplog.models import OplogEntry
 from ghostwriter.reporting.models import Finding, Observation, Report
@@ -29,7 +33,22 @@ class ExportReportBase(ExportBase):
         ).data
 
     def severity_rich_text(self, text, severity_color):
-        raise NotImplementedError()
+        """
+        Creates an exporter specific rich text object for some text related to finding severity.
+        This should be text colored by `severity_color`, if possible.
+        """
+        return text
+
+    def _severity_rich_text(self, text, severity_color):
+        if not text:
+            return ""
+        text = str(text)
+        rich_html = Markup('''<span style="color: #{};">{}</span>'''.format(
+            severity_color,
+            html.escape(text),
+        ))
+        exporter_rich = self.severity_rich_text(text, severity_color)
+        return HtmlAndRich(rich_html, exporter_rich)
 
     def map_rich_texts(self):
         base_context = copy.deepcopy(self.data)
@@ -63,9 +82,9 @@ class ExportReportBase(ExportBase):
             def finding_render(name, text):
                 return self.create_lazy_template(f"{name} of finding {finding['title']}", text, finding_rich_text_context)
 
-            finding["severity_rt"] = self.severity_rich_text(finding["severity"], finding["severity_color"])
-            finding["cvss_score_rt"] = self.severity_rich_text(finding["cvss_score"], finding["severity_color"])
-            finding["cvss_vector_rt"] = self.severity_rich_text(finding["cvss_vector"], finding["severity_color"])
+            finding["severity_rt"] = self._severity_rich_text(finding["severity"], finding["severity_color"])
+            finding["cvss_score_rt"] = self._severity_rich_text(finding["cvss_score"], finding["severity_color"])
+            finding["cvss_vector_rt"] = self._severity_rich_text(finding["cvss_vector"], finding["severity_color"])
 
             # Create subdocuments for each finding section
             finding["affected_entities_rt"] = finding_render("the affected entities section", finding["affected_entities"])

--- a/ghostwriter/modules/reportwriter/report/pptx.py
+++ b/ghostwriter/modules/reportwriter/report/pptx.py
@@ -12,9 +12,6 @@ from ghostwriter.modules.reportwriter.richtext.pptx import HtmlToPptxWithEvidenc
 
 
 class ExportReportPptx(ExportBasePptx, ExportReportBase, ProjectSlidesMixin):
-    def severity_rich_text(self, text, severity_color):
-        return text
-
     def run(self) -> io.BytesIO:
         """Generate a complete PowerPoint slide deck for the current report."""
 

--- a/ghostwriter/modules/reportwriter/report/xlsx.py
+++ b/ghostwriter/modules/reportwriter/report/xlsx.py
@@ -12,9 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 class ExportReportXlsx(ExportXlsxBase, ExportReportBase):
-    def severity_rich_text(self, text, severity_color):
-        return text
-
     def run(self) -> io.BytesIO:
         context = self.map_rich_texts()
 

--- a/ghostwriter/status/tests/test_views.py
+++ b/ghostwriter/status/tests/test_views.py
@@ -5,7 +5,7 @@ import logging
 from django.test import Client, TestCase, tag
 from django.urls import reverse
 
-logging.disable(logging.CRITICAL)
+# logging.disable(logging.CRITICAL)
 
 
 # Health checks for RAM and disk cannot be completed successfully in the GitHub CI/CD pipeline


### PR DESCRIPTION
Alters rich text a bit more, adding in `HtmlAndRich` to store both an HTML and DOCX representation of the same text.