### PR TITLE
Remove hard-coded, preceding space of figure caption prefix

### DIFF
--- a/ghostwriter/modules/reportwriter/export_report_docx.py
+++ b/ghostwriter/modules/reportwriter/export_report_docx.py
@@ -53,7 +53,7 @@ class ExportReportDocx(ExportReportBase):
 
         # Caption options
         prefix_figure = global_report_config.prefix_figure.strip()
-        self.prefix_figure = f" {prefix_figure} "
+        self.prefix_figure = f"{prefix_figure} "
         label_figure = global_report_config.label_figure.strip()
         self.label_figure = f"{label_figure} "
         self.title_case_captions = global_report_config.title_case_captions


### PR DESCRIPTION
### Description of the Change

Removed the hard-coded space that precedes the figure caption prefix to permit captions similar to Table captions, such as `Figure N. Xyz...`.

The relevant change is on line 56, `self.prefix_figure = f"{prefix_figure} "`. All other changes were formatting to pass `black` and `flake8` checks.

Before:

- `prefix` = `"."`
- `figure_prefix` = `" {prefix} "`
- `{figure_label} N{figure_prefix}` -> `"Figure N . "`

After:

- `prefix` = `"."`
- `figure_prefix` = `"{prefix} "`
- `{figure_label} N{figure_prefix}` -> `"Figure N. "`


### Alternate Designs

There were no other methods observed to prevent the preceding space that would allow for `Figure N. Xyz...`.

It might be beneficial in the long-term to remove the hard-coded space after the prefix, too, to provide the most flexibility for Ghostwriter admins and users.


### Possible Drawbacks

This will require current users that expect the preceding, hard-coded space to change their figure prefix from "-" to " -" if they need the spacing. Or, perhaps, this PR should be accompanied by a modification to add a space to the current figure prefix. I'll look into that.

Re-configuring the install defaults from "-" to " -" may be desired, too.


### Verification Process

1. Built Ghostwriter instance with the change.
2. Generated report and confirmed that space was removed in Figure caption.

I'll follow up with tests and needed changes whenever I can get Docker and Ghostwriter functional on my development system.


### Release Notes

- Removed hard-coded preceding space from Figure caption prefix to permit captions similar to Tables.
