### PR TITLE
Check evidence friendly names across all report evidences

### DIFF
--- a/ghostwriter/reporting/models.py
+++ b/ghostwriter/reporting/models.py
@@ -525,6 +525,15 @@ class Report(models.Model):
         cls.objects.filter(filter_docx).update(docx_template=None)
         cls.objects.filter(filter_pptx).update(pptx_template=None)
 
+    def all_evidences(self):
+        """
+        Returns a queryset of all evidences attached to the report - both directly attached and through the findings.
+        """
+        return Evidence.objects.filter(
+            Q(report__id=self.pk)
+            | Q(finding__report__id=self.pk)
+        )
+
     def __str__(self):
         return f"{self.title}"
 
@@ -727,7 +736,7 @@ class Evidence(models.Model):
         return self.report
 
     def __str__(self):
-        return f"{self.document.name}"
+        return f"{self.friendly_name} @ {self.document.name}"
 
     @property
     def filename(self):


### PR DESCRIPTION
Without this patch, evidence friendly names conflict only with other evidences on the same finding, or with other report-level evidences.

This patch checks across all evidences in the report - both report-level evidences and finding evidences - for friendly name conflicts.

This is useful since evidences create bookmarks in DOCX reports globally, so if two evidences have the same name within the entire report, it will create conflicting bookmarks, which isn't good.
