### PR TITLE
Restrict regex for finding `{{.dot}}` tags to prevent ReDoS

### DIFF
--- a/ghostwriter/modules/reportwriter/base/__init__.py
+++ b/ghostwriter/modules/reportwriter/base/__init__.py
@@ -93,7 +93,7 @@ def rich_text_template(env: jinja2.Environment, text: str) -> jinja2.Template:
             return jinja_funcs.caption(contents[8:].strip())
         return "{{ _old_dot_vars[" + repr(contents.strip()) + "]}}"
 
-    text = re.sub(r"\{\{\.(.*?)\}\}", replace_old_tag, text)
+    text = re.sub(r"\{\{\.([^\{\}]*)\}\}", replace_old_tag, text)
 
     # Replace page breaks with something that the parser can easily pick up
     text = text.replace(


### PR DESCRIPTION
Prevents exponential backtracking in the regex with malicious input. No longer matches evidences with `{` or `}` in it, but those are unlikely and evidences with `}}` wouldn't work anyway. If needed, use `mk_evidence("evidence_name")` instead.
