### PR TITLE
Improve ReportExportError to better include code context and location

### DIFF
--- a/ghostwriter/modules/reportwriter/base/docx.py
+++ b/ghostwriter/modules/reportwriter/base/docx.py
@@ -285,8 +285,8 @@ class ExportDocxBase(ExportBase):
             for var in exporter.jinja_undefined_variables:
                 warnings.append("Undefined variable: {!r}".format(var))
         except ReportExportError as error:
-            logger.exception("Template failed linting%s: %s", error.at_error(), error)
-            errors.append(f"Linting failed{error.at_error()}: {error}")
+            logger.exception("Template failed linting: %s", error)
+            errors.append(f"Linting failed: {error}")
         except Exception:
             logger.exception("Template failed linting")
             errors.append("Template rendering failed unexpectedly")

--- a/ghostwriter/modules/reportwriter/base/pptx.py
+++ b/ghostwriter/modules/reportwriter/base/pptx.py
@@ -146,8 +146,8 @@ class ExportBasePptx(ExportBase):
                     "Template can be used, but it has slides when it should be empty (see documentation)"
                 )
         except ReportExportError as error:
-            logger.exception("Template failed linting%s: %s", error.at_error(), error)
-            errors.append(f"Linting failed{error.at_error()}: {error}")
+            logger.exception("Template failed linting: %s", error)
+            errors.append(f"Linting failed: {error}")
         except Exception:
             logger.exception("Template failed linting")
             errors.append("Template rendering failed unexpectedly")

--- a/ghostwriter/modules/reportwriter/forms.py
+++ b/ghostwriter/modules/reportwriter/forms.py
@@ -1,8 +1,6 @@
 
 from django import forms
 
-import jinja2
-
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
 from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
 
@@ -20,9 +18,6 @@ class JinjaRichTextField(forms.CharField):
         super().validate(value)
         env, _ = prepare_jinja2_env(debug=True)
         try:
-            rich_text_template(env, value)
-        except jinja2.TemplateSyntaxError as e:
-            line = value.splitlines()[e.lineno - 1]
-            raise forms.ValidationError(f"{e} at `{line}`") from e
+            ReportExportError.map_jinja2_render_errors(lambda: rich_text_template(env, value))
         except ReportExportError as e:
             raise forms.ValidationError(str(e)) from e

--- a/ghostwriter/reporting/views.py
+++ b/ghostwriter/reporting/views.py
@@ -1351,11 +1351,10 @@ class ArchiveView(RoleBasedAccessControlMixin, SingleObjectMixin, View):
                 json_doc = ExportReportJson(report_instance).run()
             except ReportExportError as error:
                 logger.error(
-                    "Generation failed for %s %s and user %s%s: %s",
+                    "Generation failed for %s %s and user %s: %s",
                     report_instance.__class__.__name__,
                     report_instance.id,
                     self.request.user,
-                    error.at_error(),
                     error,
                 )
                 messages.error(
@@ -2080,16 +2079,15 @@ class GenerateReportDOCX(RoleBasedAccessControlMixin, SingleObjectMixin, View):
             docx = exporter.run()
         except ReportExportError as error:
             logger.error(
-                "DOCX generation failed for %s %s and user %s%s: %s",
+                "DOCX generation failed for %s %s and user %s: %s",
                 obj.__class__.__name__,
                 obj.id,
                 self.request.user,
-                error.at_error(),
                 error,
             )
             messages.error(
                 self.request,
-                f"Error{error.at_error()}: {error}",
+                f"Error: {error}",
                 extra_tags="alert-danger",
             )
             return HttpResponseRedirect(reverse("reporting:report_detail", kwargs={"pk": obj.id}))
@@ -2222,16 +2220,15 @@ class GenerateReportPPTX(RoleBasedAccessControlMixin, SingleObjectMixin, View):
             return response
         except ReportExportError as error:
             logger.error(
-                "PPTX generation failed for %s %s and user %s%s: %s",
+                "PPTX generation failed for %s %s and user %s: %s",
                 obj.__class__.__name__,
                 obj.id,
                 self.request.user,
-                error.at_error(),
                 error,
             )
             messages.error(
                 self.request,
-                f"Error{error.at_error()}: {error}",
+                f"Error: {error}",
                 extra_tags="alert-danger",
             )
         except Exception as error:
@@ -2331,7 +2328,7 @@ class GenerateReportAll(RoleBasedAccessControlMixin, SingleObjectMixin, View):
             )
             messages.error(
                 self.request,
-                f"Error{error.at_error()}: {error}",
+                f"Error: {error}",
                 extra_tags="alert-danger",
             )
         except Exception as error:

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -285,15 +285,14 @@ class GenerateProjectReport(RoleBasedAccessControlMixin, SingleObjectMixin, View
                 mime = exporter.mime_type()
         except ReportExportError as error:
             logger.error(
-                "Project report failed for project %s and user %s%s: %s",
+                "Project report failed for project %s and user %s: %s",
                 project.id,
                 self.request.user,
-                error.at_error(),
                 error
             )
             messages.error(
                 self.request,
-                f"Error{error.at_error()}: {error}",
+                f"Error: {error}",
                 extra_tags="alert-danger",
             )
             return HttpResponseRedirect(reverse("rolodex:project_detail", kwargs={"pk": project.id}) + "#documents")


### PR DESCRIPTION
* Remove `ReportExportError.at_error` and do it in `ReportExportError.__str__`, which is harder to miss.
* Add `ReportExportError.code_context`, holding the line near where an error occurs, and use it in `__str__`.
* `map_jinja2_render_errors` adds its location to a thrown `ReportExportError` if it doesn't have one.

This should further help narrow down Jinja template issues by providing more context.
