### PR TITLE
Fix error message from linting a docx file with invalid syntax

### DIFF
--- a/ghostwriter/modules/reportwriter/base/docx.py
+++ b/ghostwriter/modules/reportwriter/base/docx.py
@@ -267,7 +267,11 @@ class ExportDocxBase(ExportBase):
             )
             logger.info("Template loaded for linting")
 
-            for variable in exporter.word_doc.get_undeclared_template_variables(exporter.jinja_env):
+            undeclared_variables = ReportExportError.map_jinja2_render_errors(
+                lambda: exporter.word_doc.get_undeclared_template_variables(exporter.jinja_env),
+                "the DOCX template"
+            )
+            for variable in undeclared_variables:
                 if variable not in lint_data:
                     warnings.append("Potential undefined variable: {!r}".format(variable))
 


### PR DESCRIPTION
`get_undeclared_template_variables` processes the template but wasn't wrapped in `map_jinja2_render_errors`, so syntax errors weren't being caught properly and failing with a generic failure. This patch fixes it to throw correctly and show the error to the user.
