### PR TITLE
Added linting checks for style types on code styles

### DIFF
--- a/ghostwriter/modules/reportwriter/base/docx.py
+++ b/ghostwriter/modules/reportwriter/base/docx.py
@@ -280,10 +280,10 @@ class ExportDocxBase(ExportBase):
                     warnings.append("Template is missing a recommended style (see documentation): " + style)
                 if style == "CodeInline":
                     if document_styles[style].type != WD_STYLE_TYPE.CHARACTER:
-                        warnings.append("CodeInline style is not a character style")
+                        warnings.append("CodeInline style is not a character style (see documentation)")
                 if style == "CodeBlock":
                     if document_styles[style].type != WD_STYLE_TYPE.PARAGRAPH:
-                        warnings.append("CodeBlock style is not a paragraph style")
+                        warnings.append("CodeBlock style is not a paragraph style (see documentation)")
             if "Table Grid" not in document_styles:
                 errors.append("Template is missing a required style (see documentation): Table Grid")
             if p_style and p_style not in document_styles:

--- a/ghostwriter/modules/reportwriter/base/docx.py
+++ b/ghostwriter/modules/reportwriter/base/docx.py
@@ -268,8 +268,7 @@ class ExportDocxBase(ExportBase):
             logger.info("Template loaded for linting")
 
             undeclared_variables = ReportExportError.map_jinja2_render_errors(
-                lambda: exporter.word_doc.get_undeclared_template_variables(exporter.jinja_env),
-                "the DOCX template"
+                lambda: exporter.word_doc.get_undeclared_template_variables(exporter.jinja_env), "the DOCX template"
             )
             for variable in undeclared_variables:
                 if variable not in lint_data:
@@ -279,6 +278,12 @@ class ExportDocxBase(ExportBase):
             for style in EXPECTED_STYLES:
                 if style not in document_styles:
                     warnings.append("Template is missing a recommended style (see documentation): " + style)
+                if style == "CodeInline":
+                    if document_styles[style].type != WD_STYLE_TYPE.CHARACTER:
+                        warnings.append("CodeInline style is not a character style")
+                if style == "CodeBlock":
+                    if document_styles[style].type != WD_STYLE_TYPE.PARAGRAPH:
+                        warnings.append("CodeBlock style is not a paragraph style")
             if "Table Grid" not in document_styles:
                 errors.append("Template is missing a required style (see documentation): Table Grid")
             if p_style and p_style not in document_styles:

--- a/ghostwriter/reporting/templates/snippets/template_lint_results.html
+++ b/ghostwriter/reporting/templates/snippets/template_lint_results.html
@@ -15,9 +15,14 @@
         role="alert">
             <h4 style="margin-top: 0;" class="alert-heading">{{ lint_result.result|capfirst }}</h4>
             {% if lint_result.result == "success" %}
-                Template passed all linter checks, but try using it for a report to test it
+              <p>Template passed all linter checks, but try using it for a report to test it with findings and custom fields.</p>
             {% else %}
-                To correct these issues, make changes and re-upload this template
+              <p>To correct these issues, make changes and re-upload this template.
+                See the documentation for more information on how to fix these issues:<br/>
+                <a class="italic" href="https://www.ghostwriter.wiki/features/reporting/report-templates" target="_blank">
+                  https://www.ghostwriter.wiki/features/reporting/report-templates
+                </a>
+              </p>
             {% endif %}
         </div>
 


### PR DESCRIPTION
Added a check to the template linter to ensure the `CodeInline` and `CodeBlock` styles have the correct style type (character and paragraph, respectively).