### PR TITLE
Fixed DOCX list styling to use List Paragraph style

### DIFF
--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -18,8 +18,14 @@ from docx.shared import RGBColor as DocxRgbColor
 from lxml import etree
 
 # Ghostwriter Libraries
-from ghostwriter.modules.reportwriter.extensions import IMAGE_EXTENSIONS, TEXT_EXTENSIONS
-from ghostwriter.modules.reportwriter.richtext.ooxml import BaseHtmlToOOXML, parse_styles
+from ghostwriter.modules.reportwriter.extensions import (
+    IMAGE_EXTENSIONS,
+    TEXT_EXTENSIONS,
+)
+from ghostwriter.modules.reportwriter.richtext.ooxml import (
+    BaseHtmlToOOXML,
+    parse_styles,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +174,11 @@ class HtmlToDocx(BaseHtmlToOOXML):
             self.text_tracking.new_block()
             list_tracking.add_paragraph(par, this_list_level, is_ordered)
             self.process_children(
-                child.children, par=par, list_level=this_list_level, list_tracking=list_tracking, **kwargs
+                child.children,
+                par=par,
+                list_level=this_list_level,
+                list_tracking=list_tracking,
+                **kwargs,
             )
 
         if this_list_level == 0:
@@ -217,9 +227,15 @@ class HtmlToDocx(BaseHtmlToOOXML):
                 "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}type"
             ] = "auto"
             for row_idx, _ in enumerate(self.doc.tables[t_idx].rows):
-                for cell_idx, _ in enumerate(self.doc.tables[t_idx].rows[row_idx].cells):
-                    self.doc.tables[t_idx].rows[row_idx].cells[cell_idx]._tc.tcPr.tcW.type = "auto"
-                    self.doc.tables[t_idx].rows[row_idx].cells[cell_idx]._tc.tcPr.tcW.w = 0
+                for cell_idx, _ in enumerate(
+                    self.doc.tables[t_idx].rows[row_idx].cells
+                ):
+                    self.doc.tables[t_idx].rows[row_idx].cells[
+                        cell_idx
+                    ]._tc.tcPr.tcW.type = "auto"
+                    self.doc.tables[t_idx].rows[row_idx].cells[
+                        cell_idx
+                    ]._tc.tcPr.tcW.w = 0
         return self.doc
 
 
@@ -282,7 +298,9 @@ class HtmlToDocxWithEvidence(HtmlToDocx):
             word_list = re.split(" ", s)  # re.split behaves as expected
             final = [word_list[0].capitalize()]
             for word in word_list[1:]:
-                final.append(word if word in self.title_case_exceptions else word.capitalize())
+                final.append(
+                    word if word in self.title_case_exceptions else word.capitalize()
+                )
             s = " ".join(final)
         return s
 
@@ -424,7 +442,9 @@ class HtmlToDocxWithEvidence(HtmlToDocx):
         run = par.add_run()
         r = run._r
         instrText = OxmlElement("w:instrText")
-        instrText.text = " REF \"_Ref{}\" \\h ".format(ref.replace('\\', '\\\\').replace('"', '\\"'))
+        instrText.text = ' REF "_Ref{}" \\h '.format(
+            ref.replace("\\", "\\\\").replace('"', '\\"')
+        )
         r.append(instrText)
 
         # An optional ``separate`` value to enforce a space between label and number
@@ -458,7 +478,9 @@ class ListTracking:
 
     @staticmethod
     def q_w(tag):
-        return etree.QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", tag)
+        return etree.QName(
+            "http://schemas.openxmlformats.org/wordprocessingml/2006/main", tag
+        )
 
     def add_paragraph(self, pg, level: int, is_ordered: bool):
         """
@@ -466,7 +488,9 @@ class ListTracking:
         """
         if level > len(self.level_list_is_ordered):
             raise Exception(
-                "Tried to add level {} to a list with {} existing levels".format(level, len(self.level_list_is_ordered))
+                "Tried to add level {} to a list with {} existing levels".format(
+                    level, len(self.level_list_is_ordered)
+                )
             )
         if level == len(self.level_list_is_ordered):
             self.level_list_is_ordered.append(is_ordered)
@@ -485,13 +509,20 @@ class ListTracking:
         else:
             # Create a new numbering
             numbering = doc.part.numbering_part.numbering_definitions._numbering
-            last_used_id = max((int(id) for id in numbering.xpath("w:abstractNum/@w:abstractNumId")), default=-1)
+            last_used_id = max(
+                (int(id) for id in numbering.xpath("w:abstractNum/@w:abstractNumId")),
+                default=-1,
+            )
             abstract_numbering_id = last_used_id + 1
 
             abstract_numbering = numbering.makeelement(self.q_w("abstractNum"))
-            abstract_numbering.set(self.q_w("abstractNumId"), str(abstract_numbering_id))
+            abstract_numbering.set(
+                self.q_w("abstractNumId"), str(abstract_numbering_id)
+            )
 
-            multi_level_type = abstract_numbering.makeelement(self.q_w("multiLevelType"))
+            multi_level_type = abstract_numbering.makeelement(
+                self.q_w("multiLevelType")
+            )
             multi_level_type.set(self.q_w("val"), "hybridMultilevel")
             abstract_numbering.append(multi_level_type)
 
@@ -539,5 +570,7 @@ class ListTracking:
             cache[level_list_is_ordered] = numbering_id
 
         for par, level in self.paragraphs:
-            par._p.get_or_add_pPr().get_or_add_numPr().get_or_add_numId().val = numbering_id
+            par._p.get_or_add_pPr().get_or_add_numPr().get_or_add_numId().val = (
+                numbering_id
+            )
             par._p.get_or_add_pPr().get_or_add_numPr().get_or_add_ilvl().val = level

--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -570,6 +570,7 @@ class ListTracking:
             cache[level_list_is_ordered] = numbering_id
 
         for par, level in self.paragraphs:
+            par.style = "ListParagraph"
             par._p.get_or_add_pPr().get_or_add_numPr().get_or_add_numId().val = (
                 numbering_id
             )

--- a/ghostwriter/reporting/tests/test_rich_text_docx.py
+++ b/ghostwriter/reporting/tests/test_rich_text_docx.py
@@ -195,32 +195,53 @@ class RichTextToDocxTests(TestCase):
         """
             <w:p><w:pPr/><w:r><w:t>List test one:</w:t></w:r></w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item two</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item three:</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem two</w:t></w:r>
             </w:p>
             <w:p><w:pPr/><w:r><w:t>List test two:</w:t></w:r></w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item two</w:t></w:r>
             </w:p>
         """,
@@ -247,32 +268,53 @@ class RichTextToDocxTests(TestCase):
         """
             <w:p><w:pPr/><w:r><w:t>List test one:</w:t></w:r></w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item two</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item three:</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem two</w:t></w:r>
             </w:p>
             <w:p><w:pPr/><w:r><w:t>List test two:</w:t></w:r></w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item two</w:t></w:r>
             </w:p>
         """,
@@ -303,44 +345,74 @@ class RichTextToDocxTests(TestCase):
         """
             <w:p><w:pPr/><w:r><w:t>List test one:</w:t></w:r></w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item two</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item three:</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem two</w:t></w:r>
             </w:p>
             <w:p><w:pPr/><w:r><w:t>List test two:</w:t></w:r></w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item two</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Item three:</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem one</w:t></w:r>
             </w:p>
             <w:p>
-                <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="11"/></w:numPr></w:pPr>
+                <w:pPr>
+                    <w:pStyle w:val="ListParagraph"/>
+                    <w:numPr><w:ilvl w:val="1"/><w:numId w:val="11"/></w:numPr>
+                </w:pPr>
                 <w:r><w:t>Subitem two</w:t></w:r>
             </w:p>
         """,

--- a/ghostwriter/reporting/tests/test_rich_text_docx.py
+++ b/ghostwriter/reporting/tests/test_rich_text_docx.py
@@ -1,10 +1,15 @@
+# Standard Libraries
 from io import BytesIO
 from zipfile import ZipFile
-from lxml import etree
-import docx
 
+# Django Imports
 from django.test import TestCase
 
+# 3rd Party Libraries
+import docx
+from lxml import etree
+
+# Ghostwriter Libraries
 from ghostwriter.modules.reportwriter.richtext.docx import HtmlToDocx
 
 WORD_PREFIX = """<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
@@ -585,5 +590,5 @@ class RichTextToDocxTests(TestCase):
             <w:pPr><w:jc w:val="left"/></w:pPr>
             <w:r><w:t>Paragraph with a class</w:t></w:r>
         </w:p>
-        """
+        """,
     )


### PR DESCRIPTION
# Identify the Bug

List items are incorrectly styled as Normal when they should be styled with List Paragraph.

# Description of the Change

- Apply "List Paragraph" style to list paragraphs
- Adjusted tests to check for styling

Current/Before generated XML:

```
<w:p>
    <w:pPr>
        <w:numPr>
            <w:ilvl w:val="0"/>
            <w:numId w:val="32"/>
        </w:numPr>
    </w:pPr>
    <w:r>
        <w:t>List item</w:t>
    </w:r>
</w:p>
```

Corrected/Fixed generated XML:
```
<w:p>
    <w:pPr>
        <w:pStyle w:val="ListParagraph"/>
        <w:numPr>
            <w:ilvl w:val="0"/>
            <w:numId w:val="32"/>
        </w:numPr>
    </w:pPr>
    <w:r>
        <w:t>List item</w:t>
    </w:r>
</w:p>
```

# Alternate Designs

None.

# Possible Drawbacks

None

# Verification Process

1. Updated tests to check for correct style in generated XML.
2. Manual verification of generated reports.

### Release Notes

- Fixed Docx list paragraph style
