### PR TITLE
Don't show client projects for users just assigned to a project

### DIFF
--- a/ghostwriter/rolodex/models.py
+++ b/ghostwriter/rolodex/models.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.urls import reverse
+from django.db.models import Q
 
 # 3rd Party Libraries
 from taggit.managers import TaggableManager
@@ -74,6 +75,26 @@ class Client(models.Model):
 
     def __str__(self):
         return f"{self.name}"
+
+    @classmethod
+    def for_user(cls, user):
+        """
+        Retrieve a filtered list of :model:`rolodex.Client` entries based on the user's role.
+
+        Privileged users will receive all entries. Non-privileged users will receive only those entries to which they
+        have access.
+        """
+        if user.is_privileged:
+            return cls.objects.all().order_by("name")
+        return (
+            cls.objects.filter(
+                Q(clientinvite__user=user)
+                | Q(project__projectinvite__user=user)
+                | Q(project__projectassignment__operator=user)
+            )
+            .order_by("name")
+            .distinct()
+        )
 
 
 class ClientContact(models.Model):
@@ -232,6 +253,26 @@ class Project(models.Model):
 
     def __str__(self):
         return f"{self.start_date} {self.client} {self.project_type} ({self.codename})"
+
+    @classmethod
+    def for_user(cls, user):
+        """
+        Retrieve a filtered list of :model:`rolodex.Project` entries based on the user's role.
+
+        Privileged users will receive all entries. Non-privileged users will receive only those entries to which they
+        have access.
+        """
+        if user.is_privileged:
+            return cls.objects.select_related("client").all().order_by("complete", "client")
+        return (
+            cls.objects.select_related("client")
+            .filter(
+                Q(client__clientinvite__user=user)
+                | Q(projectinvite__user=user)
+                | Q(projectassignment__operator=user)
+            )
+            .order_by("complete", "client")
+        )
 
 
 class ProjectRole(models.Model):

--- a/ghostwriter/rolodex/templates/rolodex/client_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/client_detail.html
@@ -157,7 +157,7 @@
                 <hr />
 
                 <a class="icon add-icon btn btn-primary mb-3 col-3" href="{% url 'rolodex:project_create' client.id %}">Add a Project</a>
-                {% if client.project_set.all %}
+                {% if projects %}
                     <table id="projectTable" class="tablesorter table">
                         <thead>
                             <tr>
@@ -168,7 +168,7 @@
                                 <th class="sorter-false">Options</th>
                             </tr>
                         </thead>
-                        {% for project in client.project_set.all %}
+                        {% for project in projects %}
                             <tr>
                                 <td class="align-middle"><a class="clickable" href="{{ project.get_absolute_url }}">{{ project.codename }}</a></td>
                                 <td class="align-middle">{{ project.project_type }}</td>

--- a/ghostwriter/rolodex/templates/rolodex/client_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/client_detail.html
@@ -255,6 +255,45 @@
                 {% endif %}
             </div>
 
+            {% comment %} Invitations {% endcomment %}
+            {% if request.user|is_privileged %}
+                <div id="invitations" class="tab-pane">
+                    <h4>Invitations</h4>
+                    <hr />
+                    <p class="text-justify offset-2 col-8">Users listed here have view access to this client and all of their projects, infrastructure, etc.</p>
+                    <a class="icon add-icon btn btn-primary mb-3 col-3" href="{% url 'rolodex:client_update' client.id %}#invites">Add Invitation</a>
+                    {% if client.clientinvite_set.all %}
+                        <table id="clientTable" class="tablesorter table table-striped">
+                            <thead>
+                                <tr>
+                                    <th class="align-middle pr-4">Name</th>
+                                    <th class="align-middle pr-4">Comment</th>
+                                </tr>
+                            </thead>
+                            {% for invite in client.clientinvite_set.all %}
+                                <tr>
+                                    <td class="align-middle">
+                                        <a class="clickable" href="{% url 'users:user_detail' invite.user.username %}">
+                                            {% if invite.user.name %}
+                                                {{ invite.user.name }}
+                                            {% else %}
+                                                Missing Full Name ({{ invite.user.username|capfirst }})
+                                            {% endif %}
+                                        </a>
+                                    </td>
+
+                                    <td class="align-middle">
+                                        {{ invite.comment|bleach }}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    {% else %}
+                        <div class="alert alert-warning offset-md-2 col-md-8 mt-1" role="alert">There is nothing to see here yet.</div>
+                    {% endif %}
+                </div>
+            {% endif %}
+
             {% comment %} Extra Fields Tab {% endcomment %}
             {% if client_extra_fields_spec %}
                 <div id="extra_fields" class="tab-pane">

--- a/ghostwriter/rolodex/templates/rolodex/client_form.html
+++ b/ghostwriter/rolodex/templates/rolodex/client_form.html
@@ -43,14 +43,6 @@
   {% crispy form form.helper %}
 {% endblock %}
 
-{% block tabs %}
-  {{ block.super }}
-{% endblock %}
-
-{% block tabforms %}
-  {{ block.super }}
-{% endblock %}
-
 {% block morescripts %}
   <script>
     {% comment %} Formset manipulation buttons {% endcomment %}
@@ -62,6 +54,17 @@
       new_form.find('span.counter').html(parseInt(form_idx) + 1);
       new_form.fadeOut(100).fadeIn(100).fadeOut(100).fadeIn(100);
       let target = 'id_{{ contacts.prefix }}-' + parseInt(form_idx) + '-note'
+      tinymce.execCommand('mceAddEditor', false, target);
+    });
+
+    $('.formset-add-{{ invites.prefix }}').click(function () {
+      let form_idx = $('#id_{{ invites.prefix }}-TOTAL_FORMS').val();
+      $('#formset-{{ invites.prefix }}').append($('#empty-form-{{ invites.prefix }}').html().replace(/__prefix__/g, form_idx));
+      $('#id_{{ invites.prefix }}-TOTAL_FORMS').val(parseInt(form_idx) + 1);
+      let new_form = $('#formset-{{ invites.prefix }}').find('div.formset-container').last()
+      new_form.find('span.counter').html(parseInt(form_idx) + 1);
+      new_form.fadeOut(100).fadeIn(100).fadeOut(100).fadeIn(100);
+      let target = 'id_{{ invites.prefix }}-' + parseInt(form_idx) + '-comment'
       tinymce.execCommand('mceAddEditor', false, target);
     });
 

--- a/ghostwriter/rolodex/templates/snippets/client_nav_tabs.html
+++ b/ghostwriter/rolodex/templates/snippets/client_nav_tabs.html
@@ -1,3 +1,4 @@
+{% load custom_tags %}
 <li class="nav-item">
     <a id="id_general" class="nav-link active tab-icon company-icon" data-toggle="tab" href="#general">
         General Info
@@ -18,6 +19,13 @@
         Infrastructure History <span class="badge badge-pill badge-light">{{ client.project_set.history_set.all.count }}</span>
     </a>
 </li>
+{% if request.user|is_privileged %}
+<li class="nav-item">
+    <a id="id_invitations" class="nav-link tab-icon users-icon" data-toggle="tab" href="#invitations">
+        Invitations <span class="badge badge-pill badge-light">{{ client.clientinvite_set.all.count }}</span>
+    </a>
+</li>
+{% endif %}
 {% if client_extra_fields_spec %}
     <li class="nav-item">
         <a id="id_extra_fields" class="nav-link tab-icon custom-field-icon" data-toggle="tab" href="#extra_fields">

--- a/ghostwriter/users/models.py
+++ b/ghostwriter/users/models.py
@@ -114,6 +114,13 @@ class User(AbstractUser):
         """Return a hex-encoded username to ensure the username is safe for WebSockets channel names."""
         return hexlify(self.username.encode()).decode()
 
+    @property
+    def is_privileged(self):
+        """
+        Verify that the user holds a privileged role or the ``is_staff`` flag.
+        """
+        return self.role in ("admin", "manager") or self.is_staff
+
     def save(self, *args, **kwargs):
         # Align Django's permissions flags with the chosen role
         if self.role == "user":


### PR DESCRIPTION
This is a breaking change in how permissions work. Currently, if an
operator is assigned to any project for a client, they get read access
to all of the client's other projects as well. This patch changes that
to only allow access to the project they've been assigned.

Management and users with client invitations still have full view
access.

Also adds UI for adding/removing client invitations.