### PR TITLE
Load settings from local.d and production.d

### DIFF
--- a/config/settings/local.d/.gitignore
+++ b/config/settings/local.d/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -70,3 +70,9 @@ INSTALLED_APPS += ["django_extensions"]  # noqa F405
 # LOGGING.setdefault("loggers", {})["django.db.backends"] = {
 #     "level": "DEBUG"
 # }
+
+
+# Include files in `local.d`. These are added in alphabetical order - using a numeric prefix
+# like `10-subconfig.py` can be used to order inclusions
+
+include_settings("./local.d/*.py")

--- a/config/settings/production.d/.gitignore
+++ b/config/settings/production.d/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -162,3 +162,9 @@ LOGGING = {
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+
+# Include files in `production.d`. These are added in alphabetical order - using a numeric prefix
+# like `10-subconfig.py` can be used to order inclusions
+
+include_settings("./production.d/*.py")


### PR DESCRIPTION
Allows settings overrides that aren't tracked by Git and won't cause merge conflicts on upgrades.
