### PR TITLE
Fix error for documents without ListParagraph style

### DIFF
--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -209,7 +209,7 @@ class HtmlToDocx(BaseHtmlToOOXML):
 
     tag_ol = tag_ul
 
-    def tag_blockquote(self, el, **kwargs):
+    def tag_blockquote(self, el, par=None, **kwargs):
         # TODO: if done in a list, this won't preserve the level.
         # Not sure how to do that, since this requires a new paragraph.
         par = self.doc.add_paragraph()


### PR DESCRIPTION
Also adds checking in a few other places where styles are assigned.

In my experience, deleting the list paragraph style will also delete the
numberings XML document entirely, which python-docx cannot recreate.
This patch also checks for that and shows the user a more friendly error
message.

Fixes #499 