### PR TITLE
Fixed domains marked as expired not returning to available if renewed

### DIFF
--- a/ghostwriter/shepherd/forms.py
+++ b/ghostwriter/shepherd/forms.py
@@ -183,7 +183,7 @@ class DomainForm(forms.ModelForm):
         for field in self.fields:
             self.fields[field].widget.attrs["autocomplete"] = "off"
         self.fields["name"].widget.attrs["placeholder"] = "ghostwriter.wiki"
-        self.fields["registrar"].widget.attrs["placeholder"] = "NameCheap"
+        self.fields["registrar"].widget.attrs["placeholder"] = "Namecheap"
         self.fields["domain_status"].empty_label = "-- Select Status --"
         self.fields["whois_status"].empty_label = "-- Select Status --"
         self.fields["health_status"].empty_label = "-- Select Status --"

--- a/ghostwriter/shepherd/tasks.py
+++ b/ghostwriter/shepherd/tasks.py
@@ -760,6 +760,8 @@ def fetch_namecheap_domains():
         domain_queryset = Domain.objects.filter(registrar="Namecheap")
         expired_status = DomainStatus.objects.get(domain_status="Expired")
         burned_status = DomainStatus.objects.get(domain_status="Burned")
+        unavailable_status = DomainStatus.objects.get(domain_status="Unavailable")
+        available_status = DomainStatus.objects.get(domain_status="Available")
         health_burned_status = HealthStatus.objects.get(health_status="Burned")
         for domain in domain_queryset:
             # Check if a domain in the library is _not_ in the Namecheap response
@@ -799,6 +801,17 @@ def fetch_namecheap_domains():
                         domain=domain,
                         note="Automatically set to Expired because the domain did not appear in Namecheap during a sync.",
                     )
+            # Catch domains that were marked as expired but are now back in the Namecheap data
+            else:
+                if domain.expired:
+                    logger.info("Domain %s is marked as expired but is now back in the Namecheap data", domain.name)
+                    domain_changes["updates"][domain.id] = {}
+                    domain_changes["updates"][domain.id]["domain"] = domain.name
+                    domain_changes["updates"][domain.id]["change"] = "renewed"
+                    domain.expired = False
+                    domain.domain_status = available_status
+                    domain.save()
+
         # Now, loop over every domain returned by Namecheap
         for domain in domains_list:
             logger.info("Domain %s is now being processed", domain["Name"])
@@ -840,8 +853,12 @@ def fetch_namecheap_domains():
                 ] = "<p>Namecheap has locked the domain. This is usually the result of a legal complaint related to phishing/malicious activities.</p>"
 
             # Set AutoRenew status
+            # Ignore Namecheap's `AutoRenew` value if the domain is expired (both can be true)
             if domain["AutoRenew"] == "false" or domain["IsExpired"] == "true":
                 entry["auto_renew"] = False
+            # Ensure the domain's auto-renew status in the database matches Namecheap
+            elif domain["AutoRenew"] == "true":
+                entry["auto_renew"] = True
 
             # Convert Namecheap dates to Django
             entry["creation"] = datetime.strptime(domain["Created"], "%m/%d/%Y").strftime("%Y-%m-%d")

--- a/ghostwriter/shepherd/tasks.py
+++ b/ghostwriter/shepherd/tasks.py
@@ -760,7 +760,6 @@ def fetch_namecheap_domains():
         domain_queryset = Domain.objects.filter(registrar="Namecheap")
         expired_status = DomainStatus.objects.get(domain_status="Expired")
         burned_status = DomainStatus.objects.get(domain_status="Burned")
-        unavailable_status = DomainStatus.objects.get(domain_status="Unavailable")
         available_status = DomainStatus.objects.get(domain_status="Available")
         health_burned_status = HealthStatus.objects.get(health_status="Burned")
         for domain in domain_queryset:
@@ -809,7 +808,8 @@ def fetch_namecheap_domains():
                     domain_changes["updates"][domain.id]["domain"] = domain.name
                     domain_changes["updates"][domain.id]["change"] = "renewed"
                     domain.expired = False
-                    domain.domain_status = available_status
+                    if domain.domain_status == expired_status:
+                        domain.domain_status = available_status
                     domain.save()
 
         # Now, loop over every domain returned by Namecheap


### PR DESCRIPTION
This hotfix addresses an edge case with the Namecheap sync background task. If a domain expires but it later renewed while in the grace period (or potentially repurchased at a later time) the task does not flip the domain's staus from "Exopired" to "Available." If a domain exists in the Namecheap library and is marked as expired, this change adjusts the status to "Available" and ensures the auto-renew status is updated.