### PR TITLE
Set to default_pptx_template

### DIFF
--- a/ghostwriter/reporting/views.py
+++ b/ghostwriter/reporting/views.py
@@ -1362,7 +1362,7 @@ class ArchiveView(RoleBasedAccessControlMixin, SingleObjectMixin, View):
             if report_instance.pptx_template:
                 pptx_template = report_instance.pptx_template.document.path
             else:
-                pptx_template = report_config.default_docx_template
+                pptx_template = report_config.default_pptx_template
                 if not pptx_template:
                     raise MissingTemplate
 


### PR DESCRIPTION
Closes #527 
As mentioned in the linked issue the ArchiveView defaults to the default_docx_template by mistake when the report has no pptx_template configured