### PR TITLE
Fix oplog import requiring extra fields, and document the column

### DIFF
--- a/ghostwriter/oplog/templates/oplog/oplog_import.html
+++ b/ghostwriter/oplog/templates/oplog/oplog_import.html
@@ -57,6 +57,7 @@
         </em>
         <p class="mt-3">The <em>entry_identifer</em> field can be empty or a unique value for the log entry. If an existing log
           entry shares the same <em>entry_identifer</em> it will be updated with the imported values.</p>
+        <p class="mt-3">An <em>extra_fields</em> column can optionally be provided. It should contain a JSON object with field interal names for keys.</p>
       </div>
     </div>
 

--- a/ghostwriter/oplog/views.py
+++ b/ghostwriter/oplog/views.py
@@ -220,7 +220,7 @@ class OplogSanitize(RoleBasedAccessControlMixin, SingleObjectMixin, View):
 
 def validate_headers(imported_data):
     """Validate the headers of the CSV file for an activity log import."""
-    headers = [
+    expected_header_count = collections.Counter([
         "entry_identifier",
         "start_date",
         "end_date",
@@ -234,9 +234,10 @@ def validate_headers(imported_data):
         "comments",
         "operator_name",
         "tags",
-        "extra_fields",
-    ]
-    return collections.Counter(imported_data.headers) == collections.Counter(headers)
+    ])
+    actual_header_count = collections.Counter(imported_data.headers)
+    num_extra_fields = actual_header_count.pop("extra_fields", 0)
+    return expected_header_count == actual_header_count and num_extra_fields in (0,1)
 
 
 def validate_log_selection(user, oplog_id):


### PR DESCRIPTION
Oplog imports would reject CSV files without an "extra_fields" column, which was missing in the page's documentation of the required CSV columns. Since the parsing code treats it as optional, change the validation to pass if it's not provided.

Also mention the column in the documentation.

