### PR TITLE
Minor Changes for CVSS and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # CHANGELOG
 
+# [4.3.3] - 21 October 2024
+
+### Added
+
+* Added display for the temporal and environmental scores on the CVSS v3.1 calculator (Closes #536)
+* Added a `cvss_data` key to the report context that includes the CVSS data for each finding
+  * The key is a list that includes four items: the CVSS version, score(s), severity, and your configured color for the severity
+  * The score and severity data includes the temporal and environmental scores for CVSS v3.1, so those scores, severities, and colors are lists (base, temporal, environmental)
+  * The data is available for use in the report template
+
+### Fixed
+
+* Fixed values of zero (e.g., `0` or `0.0`) displaying as "No Value Set" for extra fields (Closes #541)
+* Fixed a minor style issue with the sidebar
+
 ## [4.3.2] - 30 Sep 2024
 
 ### Added

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v4.3.2
-30 September 2024
+v4.3.3
+21 October 2024

--- a/ghostwriter/commandcenter/templates/user_extra_fields/field.html
+++ b/ghostwriter/commandcenter/templates/user_extra_fields/field.html
@@ -17,6 +17,6 @@
         })
     </script>
   {% else %}
-    {% if field_value %}{{ field_value }}{% else %}No Value Set{% endif %}
+    {% if field_value or field_value == 0 %}{{ field_value }}{% else %}No Value Set{% endif %}
   {% endif %}
 {% endwith %}

--- a/ghostwriter/commandcenter/templates/user_extra_fields/field.html
+++ b/ghostwriter/commandcenter/templates/user_extra_fields/field.html
@@ -17,6 +17,6 @@
         })
     </script>
   {% else %}
-    {% if field_value or field_value == 0 %}{{ field_value }}{% else %}No Value Set{% endif %}
+    {%  if field_value is None %}No Value Set{% else %}{{ field_value }}{% endif %}
   {% endif %}
 {% endwith %}

--- a/ghostwriter/modules/custom_serializers.py
+++ b/ghostwriter/modules/custom_serializers.py
@@ -235,6 +235,7 @@ class FindingLinkSerializer(TaggitSerializer, CustomModelSerializer):
     severity_color_rgb = SerializerMethodField("get_severity_color_rgb")
     severity_color_hex = SerializerMethodField("get_severity_color_hex")
     extra_fields = ExtraFieldsSerField(Finding._meta.label)
+    cvss_data = SerializerMethodField("get_cvss_data")
     tags = TagListSerializerField()
 
     # Include a copy of the ``mitigation`` field as ``recommendation`` to match legacy JSON output
@@ -267,6 +268,9 @@ class FindingLinkSerializer(TaggitSerializer, CustomModelSerializer):
 
     def get_severity_color_hex(self, obj):
         return obj.severity.color_hex
+
+    def get_cvss_data(self, obj):
+        return obj.cvss_data
 
 
 class ObservationLinkSerializer(TaggitSerializer, CustomModelSerializer):

--- a/ghostwriter/reporting/templates/snippets/cvss_ui.html
+++ b/ghostwriter/reporting/templates/snippets/cvss_ui.html
@@ -29,9 +29,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         {% include "snippets/cvss_ui_v3.html" %}
     </div>
 
-    <div class="scoreRating">
+    <div class="scoreRating baseRating">
+        <h4>Base</h4>
         <span class="baseMetricScore"></span>
-        <span class="baseSeverity">Select values for all base metrics</span>
+        <span class="baseSeverity">Select values to see score</span>
+    </div>
+    <div class="scoreRating temporalRating">
+        <h4>Temporal</h4>
+        <span class="temporalMetricScore"></span>
+        <span class="temporalSeverity">Select values to see score</span>
+    </div>
+    <div class="scoreRating envRating">
+        <h4>Env</h4>
+        <span class="envMetricScore"></span>
+        <span class="envSeverity">Select values to see score</span>
     </div>
 </div>
 
@@ -43,8 +54,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         {% include "snippets/cvss_ui_v4.html" %}
     </div>
 
-    <div class="scoreRating">
+    <div class="scoreRating baseRating">
+      <h4>Base</h4>
         <span class="baseMetricScore"></span>
-        <span class="baseSeverity">Select values for all base metrics</span>
+        <span class="baseSeverity">Select values to see score</span>
     </div>
 </div>

--- a/ghostwriter/reporting/templates/snippets/cvss_ui_v4.html
+++ b/ghostwriter/reporting/templates/snippets/cvss_ui_v4.html
@@ -1322,13 +1322,13 @@
                         >
                             Not Defined (X)
                         </label>
-                        <input
-                            type="radio"
-                            name="cvssv4_MSC"
-                            id="cvssv4_MSC_undefined"
-                            value="undefined"
-                        />
-                        <label for="cvssv4_MSC_undefined" title=""></label>
+{#                        <input#}
+{#                            type="radio"#}
+{#                            name="cvssv4_MSC"#}
+{#                            id="cvssv4_MSC_undefined"#}
+{#                            value="undefined"#}
+{#                        />#}
+{#                        <label for="cvssv4_MSC_undefined" title="" style="display:none;"></label>#}
                         <input
                             type="radio"
                             name="cvssv4_MSC"

--- a/ghostwriter/reporting/templates/snippets/cvss_ui_v4.html
+++ b/ghostwriter/reporting/templates/snippets/cvss_ui_v4.html
@@ -1322,13 +1322,6 @@
                         >
                             Not Defined (X)
                         </label>
-{#                        <input#}
-{#                            type="radio"#}
-{#                            name="cvssv4_MSC"#}
-{#                            id="cvssv4_MSC_undefined"#}
-{#                            value="undefined"#}
-{#                        />#}
-{#                        <label for="cvssv4_MSC_undefined" title="" style="display:none;"></label>#}
                         <input
                             type="radio"
                             name="cvssv4_MSC"

--- a/ghostwriter/static/css/cvss_styles.css
+++ b/ghostwriter/static/css/cvss_styles.css
@@ -181,18 +181,14 @@
 
 .baseMetricScore {
     display: block;
-    /*line-height: 32px;*/
-    /*margin-top: 4px;*/
 }
 
 .envMetricScore {
     display: block;
-    /*line-height: 32px;*/
 }
 
 .temporalMetricScore {
     display: block;
-    /*line-height: 32px;*/
 }
 
 .baseSeverity {

--- a/ghostwriter/static/css/cvss_styles.css
+++ b/ghostwriter/static/css/cvss_styles.css
@@ -105,6 +105,14 @@
     text-align: center;
 }
 
+.scoreRating.temporalRating {
+    top: 105px;
+}
+
+.scoreRating.envRating {
+    top: 205px;
+}
+
 .scoreRating.none,
 .scoreRating.low,
 .scoreRating.medium,
@@ -173,11 +181,31 @@
 
 .baseMetricScore {
     display: block;
-    line-height: 32px;
-    margin-top: 4px;
+    /*line-height: 32px;*/
+    /*margin-top: 4px;*/
+}
+
+.envMetricScore {
+    display: block;
+    /*line-height: 32px;*/
+}
+
+.temporalMetricScore {
+    display: block;
+    /*line-height: 32px;*/
 }
 
 .baseSeverity {
+    margin-bottom: 10px;
+    display: block;
+}
+
+.envSeverity {
+    margin-bottom: 10px;
+    display: block;
+}
+
+.temporalSeverity {
     margin-bottom: 10px;
     display: block;
 }

--- a/ghostwriter/static/js/cvss/ui.js
+++ b/ghostwriter/static/js/cvss/ui.js
@@ -1,10 +1,32 @@
 (function() {
 
   function setCvssBadge(version, score) {
-    const severity = CVSS.severityRating(score);
-    document.querySelector(`#cvss-${version}-calculator .scoreRating`).className = "scoreRating " + severity.toLowerCase();
-    document.querySelector(`#cvss-${version}-calculator .baseMetricScore`).textContent = score;
-    document.querySelector(`#cvss-${version}-calculator .baseSeverity`).textContent = "(" + severity + ")";
+      if (version === "v4") {
+          const severity = CVSS.severityRating(score);
+          document.querySelector(`#cvss-${version}-calculator .baseRating`).className = "scoreRating baseRating " + severity.toLowerCase();
+          document.querySelector(`#cvss-${version}-calculator .baseMetricScore`).textContent = score;
+          document.querySelector(`#cvss-${version}-calculator .baseSeverity`).textContent = "(" + severity + ")";
+    }
+
+    if (version === "v3") {
+        const base = score.baseMetricScore;
+        const severity = CVSS.severityRating(base);
+        document.querySelector(`#cvss-${version}-calculator .baseRating`).className = "scoreRating baseRating " + severity.toLowerCase();
+        document.querySelector(`#cvss-${version}-calculator .baseMetricScore`).textContent = base;
+        document.querySelector(`#cvss-${version}-calculator .baseSeverity`).textContent = "(" + severity + ")";
+
+        const temporalScore = score.temporalMetricScore;
+        const temporalSeverity = CVSS.severityRating(temporalScore);
+        document.querySelector(`#cvss-${version}-calculator .temporalRating`).className = "scoreRating temporalRating " + temporalSeverity.toLowerCase();
+        document.querySelector(`#cvss-${version}-calculator .temporalMetricScore`).textContent = temporalScore;
+        document.querySelector(`#cvss-${version}-calculator .temporalSeverity`).textContent = "(" + temporalSeverity + ")";
+
+        const envScore = score.environmentalMetricScore;
+        const envSeverity = CVSS.severityRating(envScore);
+        document.querySelector(`#cvss-${version}-calculator .envRating`).className = "scoreRating envRating " + envSeverity.toLowerCase();
+        document.querySelector(`#cvss-${version}-calculator .envMetricScore`).textContent = envScore;
+        document.querySelector(`#cvss-${version}-calculator .envSeverity`).textContent = "(" + envSeverity + ")";
+    }
   }
 
   function setSeveritySelect(score) {
@@ -32,7 +54,8 @@
 
     const cvssv3Selected = CVSS.parseVector(vectorStr);
     if(cvssv3Selected) {
-      const score = CVSS.calculateCVSSFromObject(cvssv3Selected).baseMetricScore;
+      const score = CVSS.calculateCVSSFromObject(cvssv3Selected);
+
       setCvssBadge("v3", score);
       if(setScore) {
         // Set score when editing the vector but not when loading
@@ -81,10 +104,12 @@
       return;
     }
 
-    document.getElementById('id_cvss_score').value = output.baseMetricScore;
-    setCvssBadge("v3", output.baseMetricScore);
+    // Use modified environmental score if available
+    var score = output.environmentalMetricScore !== undefined ? output.environmentalMetricScore : output.baseMetricScore;
+    document.getElementById('id_cvss_score').value = score;
+    setCvssBadge("v3", output);
     document.getElementById('id_cvss_vector').value = output.vectorString;
-    setSeveritySelect(output.baseMetricScore);
+    setSeveritySelect(score);
   }
 
   function onV4ButtonChanged() {

--- a/ghostwriter/templates/base_generic.html
+++ b/ghostwriter/templates/base_generic.html
@@ -95,7 +95,7 @@
               href="{% url 'reporting:report_detail' request.session.active_report.id %}"
               >Jump to Report
             {% else %}
-              class="btn btn-primary col-10 active-report-shortcut icon ext-link-icon btn-disabled"
+              class="btn btn-primary mb-3 col-10 active-report-shortcut icon ext-link-icon btn-disabled"
               href="#"
               >Select Report Below
             {% endif %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,3 +45,4 @@ pyjwt==2.7.0
 psutil==5.9.4
 django-taggit==3.1.0
 croniter==2.0.5
+cvss==3.2


### PR DESCRIPTION
# CHANGELOG

# [4.3.3] - 21 October 2024

### Added

* Added display for the temporal and environmental scores on the CVSS v3.1 calculator (Closes #536)
* Added a `cvss_data` key to the report context that includes the CVSS data for each finding
  * The key is a list that includes four items: the CVSS version, score(s), severity, and your configured color for the severity
  * The score and severity data includes the temporal and environmental scores for CVSS v3.1, so those scores, severities, and colors are lists (base, temporal, environmental)
  * The data is available for use in the report template

### Fixed

* Fixed values of zero (e.g., `0` or `0.0`) displaying as "No Value Set" for extra fields (Closes #541)
* Fixed a minor style issue with the sidebar