### PR TITLE
Fix evidence refs with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.3.7] - 25 November 2024
+
+#### Fixed
+
+* Fixed forms not accepting decimal values for extra fields (PR #554)
+* Fixed cross-references not working when the reference name contained spaces (PR #556)
+
 ## [4.3.6] - 14 November 2024
 
 ### Added

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v4.3.6
-14 November 2024
+v4.3.7
+25 November 2024

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,9 +11,9 @@ from django.contrib.messages import constants as messages
 # 3rd Party Libraries
 import environ
 
-__version__ = "4.3.6"
+__version__ = "4.3.7"
 VERSION = __version__
-RELEASE_DATE = "14 November 2024"
+RELEASE_DATE = "25 November 2024"
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 APPS_DIR = ROOT_DIR / "ghostwriter"


### PR DESCRIPTION
For some reason, MS Word ignores bookmarks with spaces in them. I can't find any restrictions on bookmark names in the spec. This patch replaces spaces with underscores.

This also adds some bookmark ID tracking rather than using ID "0" for every bookmark.
