### PR TITLE
Evidence Preview Adjustments

### DIFF
--- a/ghostwriter/reporting/templates/reporting/evidence_detail.html
+++ b/ghostwriter/reporting/templates/reporting/evidence_detail.html
@@ -91,6 +91,7 @@
   <p>This is a preview of what your evidence file will look like in a report.
     It may not look exactly like this (depending on your template's styles),
     but it will give you an idea of what to expect.</p>
+  <p>The width is 6.5" (165.1mm), the default full width of a Word document.</p>
   <p>If you have borders enabled for reports, images will include a border with your configured color and width.</p>
   <p>Previews also show you what captions will look like with your caption and configured labelling for figures.</p>
 

--- a/ghostwriter/reporting/templates/snippets/evidence_display.html
+++ b/ghostwriter/reporting/templates/snippets/evidence_display.html
@@ -21,5 +21,5 @@
       {% endif %}
     </div>
   {% endif %}
-  <p class="evidence-caption">{{ report_config.label_figure }} # {{ report_config.prefix_figure }} {{ evidence.caption }}</p>
+  <p class="evidence-caption">{{ report_config.label_figure }}#{{ report_config.prefix_figure }}{{ evidence.caption }}</p>
 {% endwith %}

--- a/ghostwriter/static/css/styles.css
+++ b/ghostwriter/static/css/styles.css
@@ -77,7 +77,7 @@ hr {
 
 .img-evidence {
   height: auto;
-  max-width: 60vw;
+  max-width: 6.5in;
   display: block;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
This is a minor update to set evidence previews to 6.5" wide, which matches how they appear in a standard Word document.