### PR TITLE
Small holiday adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.9] - 10 December 2024
+
+### Changed
+
+* Evidence previews for custom fields and evidence detail pages now display evidence at 6.5" wide to mimic the standard full-width seen in a Word document
+
+### Fixed
+
+* Fixed an issue that could cause improper casing for the first word in a caption
+
 ## [4.3.8] - 6 December 2024
 
 ### Added

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v4.3.8
-6 December 2024
+v4.3.9
+10 December 2024

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,9 +11,9 @@ from django.contrib.messages import constants as messages
 # 3rd Party Libraries
 import environ
 
-__version__ = "4.3.8"
+__version__ = "4.3.9"
 VERSION = __version__
-RELEASE_DATE = "6 December 2024"
+RELEASE_DATE = "10 December 2024"
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 APPS_DIR = ROOT_DIR / "ghostwriter"

--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -351,8 +351,8 @@ class HtmlToDocxWithEvidence(HtmlToDocx):
         """
         if self.title_case_captions:
             word_list = re.split(" ", s)  # re.split behaves as expected
-            final = [word_list[0].capitalize()]
-            for word in word_list[1:]:
+            final = []
+            for word in word_list:
                 final.append(
                     word
                     if word in self.title_case_exceptions or word.isupper() or self.is_plural_acronym(word)


### PR DESCRIPTION
# CHANGELOG

## [4.3.9] - 10 December 2024

### Changed

* Evidence previews for custom fields and evidence detail pages now display evidence at 6.5" wide to mimic the standard full-width seen in a Word document

### Fixed

* Fixed an issue that could cause improper casing for the first word in a caption