### PR TITLE
Add a None check to avoid crash

### DIFF
--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -105,7 +105,7 @@ class HtmlToDocx(BaseHtmlToOOXML):
         self.text_tracking.new_block()
         if "data-gw-pagebreak" in el.attrs:
             self.doc.add_page_break()
-        else:
+        elif par is not None:
             run = par.add_run()
             run.add_break()
 


### PR DESCRIPTION
### Identify the Bug
Bug issue:
https://github.com/GhostManager/Ghostwriter/issues/562

### Description of the Change
Added the missing check.

### Verification Process
The  report generation does not crash now.

### Release Notes
Fixed AttributeError.

