### PR TITLE
Fix project create form internal error on invalid input

### DIFF
--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -1664,6 +1664,7 @@ class ProjectCreate(RoleBasedAccessControlMixin, CreateView):
         return ctx
 
     def get(self, request, *args, **kwargs):
+        self.object = None
         self.assignments = ProjectAssignmentFormSet(prefix="assign")
         self.assignments.extra = 1
         self.invites = ProjectInviteFormSet(prefix="invite")
@@ -1671,6 +1672,7 @@ class ProjectCreate(RoleBasedAccessControlMixin, CreateView):
         return super().get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
+        self.object = None
         form = self.get_form()
         self.assignments = ProjectAssignmentFormSet(request.POST, prefix="assign")
         self.invites = ProjectInviteFormSet(request.POST, prefix="invite")


### PR DESCRIPTION
Sets `self.object = None` on `get`/`post` like what `CreateView` does, since it's read in `form_invalid`.
