### PR TITLE
Fix multiple captioned tables not being converted

### DIFF
--- a/javascript/src/tiptap_gw/bold_italic_underline.ts
+++ b/javascript/src/tiptap_gw/bold_italic_underline.ts
@@ -17,7 +17,7 @@ function unwrapClass(node: Node, cls: string): HTMLElement {
         return n;
     }
     const wrapper = mkElem("div");
-    wrapper.appendChild(node);
+    wrapper.appendChild(node.cloneNode(true));
     return wrapper;
 }
 

--- a/javascript/src/tiptap_gw/table.ts
+++ b/javascript/src/tiptap_gw/table.ts
@@ -17,7 +17,7 @@ export const TableWithCaption = Node.create<{}>({
     group: "block",
     content: "table tableCaption",
     isolating: true,
-    // Run before regular table
+    // Parse before regular table
     priority: 101,
     parseHTML() {
         return [
@@ -38,6 +38,7 @@ export const TableWithCaption = Node.create<{}>({
                 },
                 contentElement: (node) => {
                     // Convert to wrapped format
+                    node = node.cloneNode(true);
                     const caption = (node as HTMLElement).getElementsByTagName(
                         "caption"
                     )[0];


### PR DESCRIPTION
Apparently tiptap doesn't like the DOM being modified in contentElement, which was the hack I used to convert TinyMCE table captions to this wrapped format. Cloning the node before messing with it fixes the issue.
