### PR TITLE
Add notice to admin pages about editing collab models

### DIFF
--- a/ghostwriter/commandcenter/admin.py
+++ b/ghostwriter/commandcenter/admin.py
@@ -143,3 +143,10 @@ class ExtraFieldModelAdmin(admin.ModelAdmin):
 
 
 admin.site.register(ExtraFieldModel, ExtraFieldModelAdmin)
+
+class CollabAdminBase(admin.ModelAdmin):
+    """
+    Model Admin for collab-editor-enabled models.
+    """
+    change_form_template = "collab_editing/admin/change_form.html"
+    change_list_template = "collab_editing/admin/change_list.html"

--- a/ghostwriter/commandcenter/templates/collab_editing/admin/change_form.html
+++ b/ghostwriter/commandcenter/templates/collab_editing/admin/change_form.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_form.html" %}
+
+{% block messages %}
+    {{ block.super }}
+
+    <ul class="messagelist">
+        <li class="warning">Changes made here will have no effect if the object is open in a collaborative editor!</li>
+    </ul>
+{% endblock %}

--- a/ghostwriter/commandcenter/templates/collab_editing/admin/change_list.html
+++ b/ghostwriter/commandcenter/templates/collab_editing/admin/change_list.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+
+{% block messages %}
+    {{ block.super }}
+
+    <ul class="messagelist">
+        <li class="warning">Changes made here will have no effect if the object is open in a collaborative editor!</li>
+    </ul>
+{% endblock %}

--- a/ghostwriter/reporting/admin.py
+++ b/ghostwriter/reporting/admin.py
@@ -4,9 +4,10 @@
 from django.contrib import admin
 
 # 3rd Party Libraries
-from import_export.admin import ImportExportModelAdmin
+from import_export.admin import ImportExportMixin
 
 # Ghostwriter Libraries
+from ghostwriter.commandcenter.admin import CollabAdminBase
 from ghostwriter.reporting.forms import SeverityForm
 from ghostwriter.reporting.models import (
     Archive,
@@ -19,6 +20,7 @@ from ghostwriter.reporting.models import (
     Observation,
     Report,
     ReportFindingLink,
+    ReportObservationLink,
     ReportTemplate,
     Severity,
 )
@@ -76,7 +78,7 @@ class FindingTypeAdmin(admin.ModelAdmin):
 
 
 @admin.register(Finding)
-class FindingAdmin(ImportExportModelAdmin):
+class FindingAdmin(ImportExportMixin, CollabAdminBase):
     resource_class = FindingResource
     list_display = ("title", "severity", "finding_type", "tag_list")
     list_filter = (
@@ -160,7 +162,7 @@ class ReportAdmin(admin.ModelAdmin):
 
 
 @admin.register(ReportFindingLink)
-class ReportFindingLinkAdmin(admin.ModelAdmin):
+class ReportFindingLinkAdmin(CollabAdminBase):
     list_display = ("report", "severity", "finding_type", "title", "complete", "tag_list")
     list_filter = ("severity", "finding_type", "complete", "tags")
     list_editable = (
@@ -270,7 +272,7 @@ class ReportTemplateAdmin(admin.ModelAdmin):
 
 
 @admin.register(Observation)
-class ObservationAdmin(ImportExportModelAdmin):
+class ObservationAdmin(ImportExportMixin, CollabAdminBase):
     resource_class = ObservationResource
     list_display = (
         "title",
@@ -281,3 +283,8 @@ class ObservationAdmin(ImportExportModelAdmin):
 
     def tag_list(self, obj):
         return ", ".join(o.name for o in obj.tags.all())
+
+@admin.register(ReportObservationLink)
+class ReportObservationLinkAdmin(CollabAdminBase):
+    list_display = ("report", "title")
+    list_display_links = ("report", "title")


### PR DESCRIPTION
The collab editing server will overwrite changes made in the admin panel if anyone is editing them, so warn users of this fact.
