### PR TITLE
Add postgresql config, increase max_connections

### DIFF
--- a/compose/production/postgres/Dockerfile
+++ b/compose/production/postgres/Dockerfile
@@ -1,8 +1,11 @@
 FROM postgres:16.4
 
+COPY ./compose/production/postgres/postgresql.conf /etc/postgresql/postgresql.conf
 COPY ./compose/production/postgres/maintenance /usr/local/bin/maintenance
 
 RUN find /usr/local/bin/maintenance/ -type f -exec sed -i "s/$(printf '\r')\$//" '{}' ';' \
     && chmod +x /usr/local/bin/maintenance/* \
     && mv /usr/local/bin/maintenance/* /usr/local/bin \
     && rmdir /usr/local/bin/maintenance
+
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/compose/production/postgres/postgresql.conf
+++ b/compose/production/postgres/postgresql.conf
@@ -1,0 +1,4 @@
+listen_addresses = '*'
+
+# Increase this if you experience "sorry, too many clients already" errors
+max_connections = 150


### PR DESCRIPTION
Collab editing is stressing the number of open postgresql connections, so increase that a bit.

Also provides a file for the postgresql config that administrators can edit.
