### PR TITLE
Increase Django file/data upload size limit to 10MiB

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -115,6 +115,14 @@ INSTALLED_APPS = ["collectfast"] + INSTALLED_APPS  # noqa F405
 AWS_PRELOAD_METADATA = True
 COLLECTFAST_STRATEGY = "collectfast.strategies.filesystem.FileSystemStrategy"
 
+# FILE UPLOAD SIZING
+# Useful settings to configure for GraphQL actions that upload large files like base64 encoded blobs
+# Default values for both are 2.5MiB. The options below up the values to 10MiB.
+# https://docs.djangoproject.com/en/1.11/ref/settings/#file-upload-max-memory-size
+FILE_UPLOAD_MAX_MEMORY_SIZE = 10485760
+# https://docs.djangoproject.com/en/1.11/ref/settings/#data-upload-max-memory-size
+DATA_UPLOAD_MAX_MEMORY_SIZE = 10485760
+
 # LOGGING
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#logging


### PR DESCRIPTION
### Identify the Bug
Issue: https://github.com/GhostManager/Ghostwriter/issues/647

Using the `uploadEvidence` mutation returns a 400 Bad Request response when evidence file is too large. 
```
type Mutation {
  uploadEvidence(
    file_base64: String!
    filename: String!
    friendly_name: String!
    caption: String!
    description: String
    tags: String
    report: Int
    finding: Int
  ): UploadEvidenceResult!
}
```

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.

Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
Django is the action handler for GraphQL actions. DATA_UPLOAD_MAX_MEMORY_SIZE and FILE_UPLOAD_MAX_MEMORY_SIZE default to 2.5MiB so anything beyond that size should fail to upload. In the case of `uploadEvidence`, the file is base64 encoded (which increases the size) and submitted in the body of the request. If the size of the body is greater than 2.5 MiB, the error occurs.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Might be good to expose this in the `.env` file so that it is configurable. I tried to go that route, but I think the ghostwriter-cli command was overwriting my changes to the `.env`. Could also set DATA_UPLOAD_MAX_MEMORY_SIZE and FILE_UPLOAD_MAX_MEMORY_SIZE  to `None`. This would remove the size limitations entirely. 

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
Hardcoding limits may be reached in the future. Setting no limit may result in potentila DoS conditions.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
I made these changes in my test env. Before adding the changes, I could not upload files larger than 2.5 MiB using the `uploadEvidence` mutation. After making the changes, I could upload files that were larger. These settings already exist and were set to the default values by Django. The change I have proposed explicitly sets these values to 10 MiB.

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
Increase graphql file/data upload size limit to 10MiB

<!--

Please describe the changes in a single line that explains this improvement in terms that a user can understand. This text will be used in Ghostwriter's release notes.

If this change is not user-facing or notable enough to be included in release notes you may use the strings "Not applicable" or "N/A" here.

Examples:

- Fixed ``Import Oplog`` button URL
- Support for ``ProjectScope`` export to text file

-->
