### PR TITLE
Fix permissions on graphql uploadEvidence

### DIFF
--- a/ghostwriter/api/views.py
+++ b/ghostwriter/api/views.py
@@ -792,7 +792,7 @@ class GraphqlAttachFinding(JwtRequiredMixin, HasuraActionView):
 
 class GraphqlUploadEvidenceView(JwtRequiredMixin, HasuraActionView):
     def post(self, request):
-        if self.user_obj is None or not utils.verify_user_is_privileged(self.user_obj):
+        if self.user_obj is None:
             return JsonResponse(utils.generate_hasura_error_payload("Unauthorized access", "Unauthorized"), status=401)
 
         form = ApiEvidenceForm(


### PR DESCRIPTION
Previously only worked if the uploader was a manager, now works if the uploader has edit access to the project.

Adds two tests to test rejection of unauthorized users.
