### PR TITLE
Fix extra fields on findings not saving

### DIFF
--- a/javascript/src/collab_server/handlers/finding.ts
+++ b/javascript/src/collab_server/handlers/finding.ts
@@ -110,9 +110,9 @@ const FindingHandler = simpleModelHandler(
                 findingGuidance: yjsToHtml(
                     doc.get("findingGuidance", Y.XmlFragment)
                 ),
+                extraFields,
             },
             tags: yjsToTags(doc.get("tags", Y.Map<boolean>)),
-            extraFields,
         };
     }
 );

--- a/javascript/src/collab_server/handlers/report_finding_link.ts
+++ b/javascript/src/collab_server/handlers/report_finding_link.ts
@@ -118,9 +118,9 @@ const ReportFindingLinkHandler = simpleModelHandler(
                 affectedEntities: yjsToHtml(
                     doc.get("affectedEntities", Y.XmlFragment)
                 ),
+                extraFields,
             },
             tags: yjsToTags(doc.get("tags", Y.Map<boolean>)),
-            extraFields,
         };
     }
 );


### PR DESCRIPTION
The extra field was being set in the wrong place in the gql query data.
