### PR TITLE
Fix client create form not saving extra fields

### DIFF
--- a/ghostwriter/oplog/views.py
+++ b/ghostwriter/oplog/views.py
@@ -557,10 +557,10 @@ class OplogEntryCreate(RoleBasedAccessControlMixin, AjaxTemplateMixin, CreateVie
     def get_success_url(self):
         return reverse("oplog:oplog_entries", args=(self.object.oplog_id.id,))
 
-    def form_valid(self, form):
-        # Add defaults for extra fields
-        form.instance.extra_fields = ExtraFieldSpec.initial_json(self.model)
-        return super().form_valid(self, form)
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["extra_fields"] = ExtraFieldSpec.initial_json(self.model)
+        return initial
 
 
 class OplogEntryUpdate(RoleBasedAccessControlMixin, AjaxTemplateMixin, UpdateView):

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -1275,7 +1275,6 @@ class ClientCreate(RoleBasedAccessControlMixin, CreateView):
         return self.form_invalid(form)
 
     def form_valid(self, form):
-        form.instance.extra_fields = ExtraFieldSpec.initial_json(self.model)
         try:
             with transaction.atomic():
                 # Save the parent form – will rollback if a child fails validation
@@ -1314,6 +1313,7 @@ class ClientCreate(RoleBasedAccessControlMixin, CreateView):
                 codename_verified = True
         return {
             "codename": codename,
+            "extra_fields": ExtraFieldSpec.initial_json(self.model),
         }
 
 


### PR DESCRIPTION
For forms that include extra fields, the field's initial json needs to be set on the form initial data rather than set on the model.

Fixes #668
