### PR TITLE
Always enable text justification

### DIFF
--- a/javascript/src/frontend/collab_forms/rich_text_editor/index.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/index.tsx
@@ -195,6 +195,7 @@ export function Toolbar(props: {
                         menuItem
                         chain={(c) => c.setTextAlign("left")}
                         active={{ textAlign: "left" }}
+                        enable
                     >
                         Left
                     </FormatButton>
@@ -202,6 +203,7 @@ export function Toolbar(props: {
                         menuItem
                         chain={(c) => c.setTextAlign("center")}
                         active={{ textAlign: "center" }}
+                        enable
                     >
                         Center
                     </FormatButton>
@@ -209,6 +211,7 @@ export function Toolbar(props: {
                         menuItem
                         chain={(c) => c.setTextAlign("right")}
                         active={{ textAlign: "right" }}
+                        enable
                     >
                         Right
                     </FormatButton>
@@ -216,6 +219,7 @@ export function Toolbar(props: {
                         menuItem
                         chain={(c) => c.setTextAlign("justify")}
                         active={{ textAlign: "justify" }}
+                        enable
                     >
                         Justify
                     </FormatButton>


### PR DESCRIPTION
For some reason, tiptap always returns false for `can` with these, even if applying them would work, so just keep them enabled.
