### PR TITLE
Add crypto extra to the pyjwt base requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ python-nmap==0.7.1
 python-pptx==1.0.2
 requests==2.32.3
 django-timezone-field==7.0.0
-pyjwt==2.9.0
+pyjwt[crypto]==2.9.0
 psutil==6.0.0
 django-taggit==6.1.0
 croniter==3.0.3


### PR DESCRIPTION
This may help with #666. There may be some weird conflict between `django-allauth` and Ghostwriter's `base.txt`. At least for my installations, `django-allauth` (and its dependencies, such as `pyjwt[cryto]`) are installed before `base.txt`'s `pyjwt`, so maybe the installation of the cryptography extra does not occur or gets clobbered.

[django-allauth v0.63.6](https://codeberg.org/allauth/django-allauth/src/tag/0.63.6/setup.cfg#L64) specifies:
```
    pyjwt[crypto] >= 1.7
```

Ghostwriter's [base.txt#L43](https://github.com/GhostManager/Ghostwriter/blob/master/requirements/base.txt#L43) specifies:
```
pyjwt==2.9.0
```