### PR TITLE
CVSS v3: Use temporal score if defined

### DIFF
--- a/javascript/src/frontend/collab_forms/plain_editors/cvss.tsx
+++ b/javascript/src/frontend/collab_forms/plain_editors/cvss.tsx
@@ -87,6 +87,9 @@ export default function CvssCalculator(props: {
                             if (scores.environmentalScore !== undefined) {
                                 score = scores.environmentalScore;
                                 severity = scores.environmentalSeverity!;
+                            } else if(scores.temporalScore !== undefined) {
+                                score = scores.temporalScore;
+                                severity = scores.temporalSeverity!;
                             } else {
                                 score = scores.baseScore;
                                 severity = scores.baseSeverity;


### PR DESCRIPTION
CVSS score is now set to the first defined out of the environmental score, temporal score, or base score.
