### PR TITLE
Improve report writer error handling

### DIFF
--- a/ghostwriter/modules/reportwriter/base/base.py
+++ b/ghostwriter/modules/reportwriter/base/base.py
@@ -11,7 +11,7 @@ from django.db.models import Model
 
 from ghostwriter.commandcenter.models import CompanyInformation, ExtraFieldSpec
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
-from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError, rich_text_template
 from ghostwriter.modules.reportwriter.base.html_rich_text import LazilyRenderedTemplate
 
 
@@ -84,7 +84,7 @@ class ExportBase:
 
     def create_lazy_template(self, location: str | None, text: str, context: dict) -> LazilyRenderedTemplate:
         return LazilyRenderedTemplate(
-            ReportExportError.map_jinja2_render_errors(
+            ReportExportTemplateError.map_errors(
                 lambda: rich_text_template(self.jinja_env, text),
                 location,
             ),
@@ -151,7 +151,7 @@ class ExportBase:
         data["company_name"] = CompanyInformation.get_solo().company_name
         data["now"] = datetime.now()
 
-        report_name = ReportExportError.map_jinja2_render_errors(
+        report_name = ReportExportTemplateError.map_errors(
             lambda: self.jinja_env.from_string(filename_template).render(data),
             "the template filename"
         )

--- a/ghostwriter/modules/reportwriter/base/html_rich_text.py
+++ b/ghostwriter/modules/reportwriter/base/html_rich_text.py
@@ -3,7 +3,7 @@ from typing import Any
 import jinja2
 from markupsafe import Markup
 
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 
 
 def deep_copy_with_copiers(value, typ_copiers):
@@ -42,15 +42,15 @@ class LazilyRenderedTemplate:
 
     def render_html(self):
         """
-        Will throw a `ReportExportError` if the template attempted to render itself while it was
+        Will throw a `ReportExportTemplateError` if the template attempted to render itself while it was
         rendering (i.e. infinite recursion).
         """
         if self.rendered is None:
             if self.rendering:
-                raise ReportExportError(f"Circular reference to {self.location} (ensure rich text fields are not referencing each other)")
+                raise ReportExportTemplateError(f"Circular reference to {self.location} (ensure rich text fields are not referencing each other)")
             self.rendering = True
             self.rendered = Markup(
-                ReportExportError.map_jinja2_render_errors(
+                ReportExportTemplateError.map_errors(
                     lambda: self.template.render(self.context),
                     self.location,
                 )

--- a/ghostwriter/modules/reportwriter/base/pptx.py
+++ b/ghostwriter/modules/reportwriter/base/pptx.py
@@ -16,7 +16,7 @@ from pptx.oxml.ns import nsdecls
 from pptx.enum.text import MSO_AUTO_SIZE
 
 from ghostwriter.commandcenter.models import CompanyInformation
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 from ghostwriter.modules.reportwriter.base.base import ExportBase
 from ghostwriter.modules.reportwriter.base.html_rich_text import LazilyRenderedTemplate
 from ghostwriter.modules.reportwriter.richtext.pptx import HtmlToPptxWithEvidence
@@ -59,7 +59,7 @@ class ExportBasePptx(ExportBase):
         try:
             self.ppt_presentation = Presentation(template_loc)
         except PackageNotFoundError as err:
-            raise ReportExportError("Template document file could not be found - try re-uploading it") from err
+            raise ReportExportTemplateError("Template document file could not be found - try re-uploading it") from err
         except Exception:
             logger.exception(
                 "Failed to load the provided template document for unknown reason: %s",
@@ -74,7 +74,7 @@ class ExportBasePptx(ExportBase):
         Renders a `LazilyRenderedTemplate`, converting the HTML from the TinyMCE rich text editor and inserting it into the passed in shape and slide.
         Converts HTML from the TinyMCE rich text editor and inserts it into the passed in slide and shape
         """
-        ReportExportError.map_jinja2_render_errors(
+        ReportExportTemplateError.map_errors(
             lambda: HtmlToPptxWithEvidence.run(
                 rich_text.render_html(),
                 slide=slide,
@@ -145,7 +145,7 @@ class ExportBasePptx(ExportBase):
                 warnings.append(
                     "Template can be used, but it has slides when it should be empty (see documentation)"
                 )
-        except ReportExportError as error:
+        except ReportExportTemplateError as error:
             logger.exception("Template failed linting: %s", error)
             errors.append(f"Linting failed: {error}")
         except Exception:

--- a/ghostwriter/modules/reportwriter/base/xlsx.py
+++ b/ghostwriter/modules/reportwriter/base/xlsx.py
@@ -3,7 +3,7 @@ import io
 
 from xlsxwriter.workbook import Workbook
 
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 from ghostwriter.modules.reportwriter.base.base import ExportBase
 from ghostwriter.modules.reportwriter.base.html_rich_text import LazilyRenderedTemplate
 from ghostwriter.modules.reportwriter.richtext.plain_text import html_to_plain_text
@@ -41,7 +41,7 @@ class ExportXlsxBase(ExportBase):
         Renders a `LazilyRenderedTemplate`, converting the HTML from the TinyMCE rich text editor to a plain text string
         for use in XLSX cells
         """
-        return ReportExportError.map_jinja2_render_errors(
+        return ReportExportTemplateError.map_errors(
             lambda: html_to_plain_text(
                 rich_text.render_html(),
                 self.evidences_by_id,

--- a/ghostwriter/modules/reportwriter/forms.py
+++ b/ghostwriter/modules/reportwriter/forms.py
@@ -2,7 +2,7 @@
 from django import forms
 
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
-from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError, rich_text_template
 
 
 class JinjaRichTextField(forms.CharField):
@@ -18,6 +18,6 @@ class JinjaRichTextField(forms.CharField):
         super().validate(value)
         env, _ = prepare_jinja2_env(debug=True)
         try:
-            ReportExportError.map_jinja2_render_errors(lambda: rich_text_template(env, value))
-        except ReportExportError as e:
+            ReportExportTemplateError.map_errors(lambda: rich_text_template(env, value))
+        except ReportExportTemplateError as e:
             raise forms.ValidationError(str(e)) from e

--- a/ghostwriter/modules/reportwriter/jinja_funcs.py
+++ b/ghostwriter/modules/reportwriter/jinja_funcs.py
@@ -16,10 +16,9 @@ import jinja2
 from markupsafe import Markup
 
 from ghostwriter.modules.exceptions import InvalidFilterValue
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 
 logger = logging.getLogger(__name__)
-
 
 # Custom Jinja2 filters for DOCX templates
 def filter_severity(findings, allowlist):
@@ -273,10 +272,10 @@ def mk_evidence(context: jinja2.runtime.Context, evidence_name: str) -> Markup:
     """
     evidences = context.get("_evidences")
     if evidences is None:
-        raise ReportExportError("No evidences are available in this context")
+        raise ReportExportTemplateError("No evidences are available in this context")
     evidence_id = evidences.get(evidence_name)
     if evidence_id is None:
-        raise ReportExportError(f"No such evidence with name '{evidence_name}'")
+        raise ReportExportTemplateError(f"No such evidence with name '{evidence_name}'")
     return raw_mk_evidence(evidence_id)
 
 

--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -18,7 +18,7 @@ from docx.shared import RGBColor as DocxRgbColor
 from lxml import etree
 
 # Ghostwriter Libraries
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 from ghostwriter.modules.reportwriter.extensions import (
     IMAGE_EXTENSIONS,
     TEXT_EXTENSIONS,
@@ -466,7 +466,7 @@ class HtmlToDocxWithEvidence(HtmlToDocx):
                     f'The evidence file, `{evidence["friendly_name"]},` was not recognized as a UTF-8 encoded {extension} file. '
                     "Try opening it, exporting as desired type, and re-uploading it."
                 )
-                raise ReportExportError(error_msg) from err
+                raise ReportExportTemplateError(error_msg) from err
 
             if self.figure_caption_location == "top":
                 self._mk_figure_caption(par, evidence["friendly_name"], evidence["caption"])
@@ -503,7 +503,7 @@ class HtmlToDocxWithEvidence(HtmlToDocx):
                     f'The evidence file, `{evidence["friendly_name"]},` was not recognized as a {extension} file. '
                     "Try opening it, exporting as desired type, and re-uploading it."
                 )
-                raise ReportExportError(error_msg) from e
+                raise ReportExportTemplateError(error_msg) from e
 
             if self.border_color_width is not None:
                 border_color, border_width = self.border_color_width
@@ -614,7 +614,7 @@ class ListTracking:
         try:
             numbering = doc.part.numbering_part.numbering_definitions._numbering
         except NotImplementedError as e:
-            raise ReportExportError("Tried to use a list in a template without list styles") from e
+            raise ReportExportTemplateError("Tried to use a list in a template without list styles") from e
         last_used_id = max(
             (int(id) for id in numbering.xpath("w:abstractNum/@w:abstractNumId")),
             default=-1,

--- a/ghostwriter/reporting/tests/test_rich_text_templating.py
+++ b/ghostwriter/reporting/tests/test_rich_text_templating.py
@@ -2,7 +2,7 @@
 from django.test import TestCase
 
 from ghostwriter.modules.reportwriter import prepare_jinja2_env
-from ghostwriter.modules.reportwriter.base import ReportExportError, rich_text_template
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError, rich_text_template
 
 
 class RichTextTemplatingTests(TestCase):
@@ -26,5 +26,5 @@ class RichTextTemplatingTests(TestCase):
 
     def test_prefix_not_nested(self):
         env, _ = prepare_jinja2_env(debug=True)
-        with self.assertRaisesMessage(ReportExportError, "Jinja tag prefixed with 'li' was not a descendant of a li tag"):
+        with self.assertRaisesMessage(ReportExportTemplateError, "Jinja tag prefixed with 'li' was not a descendant of a li tag"):
             rich_text_template(env, "<ol>{%li for i in thelist %}<li>{{i}}</li><li>{%li endfor %}</li></ol>")

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -30,7 +30,7 @@ from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
 from ghostwriter.commandcenter.views import CollabModelUpdate
 from ghostwriter.modules.exceptions import MissingTemplate
 from ghostwriter.modules.reportwriter import report_generation_queryset
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 from ghostwriter.modules.reportwriter.report.docx import ExportReportDocx
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.modules.reportwriter.report.pptx import ExportReportPptx
@@ -767,7 +767,7 @@ class GenerateReportDOCX(GenerateReportBase):
             exporter = ExportReportDocx(obj, template_loc=template_loc)
             report_name = exporter.render_filename(report_template.filename_override or report_config.report_filename)
             docx = exporter.run()
-        except ReportExportError as error:
+        except ReportExportTemplateError as error:
             logger.error(
                 "DOCX generation failed for %s %s and user %s: %s",
                 obj.__class__.__name__,
@@ -890,7 +890,7 @@ class GenerateReportPPTX(GenerateReportBase):
             add_content_disposition_header(response, report_name)
 
             return response
-        except ReportExportError as error:
+        except ReportExportTemplateError as error:
             logger.error(
                 "PPTX generation failed for %s %s and user %s: %s",
                 obj.__class__.__name__,
@@ -982,7 +982,7 @@ class GenerateReportAll(GenerateReportBase):
             response.write(zip_buffer.read())
 
             return response
-        except ReportExportError as error:
+        except ReportExportTemplateError as error:
             logger.exception(
                 "All report generation failed unexpectedly for %s %s and user %s",
                 obj.__class__.__name__,

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -34,7 +34,7 @@ from ghostwriter.api.utils import (
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
 from ghostwriter.modules import codenames
 from ghostwriter.modules.model_utils import to_dict
-from ghostwriter.modules.reportwriter.base import ReportExportError
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 from ghostwriter.modules.reportwriter.project.json import ExportProjectJson
 from ghostwriter.modules.shared import add_content_disposition_header
 from ghostwriter.reporting.models import ReportTemplate
@@ -293,7 +293,7 @@ class GenerateProjectReport(RoleBasedAccessControlMixin, SingleObjectMixin, View
                 filename = exporter.render_filename(template.filename_override or report_config.project_filename)
                 out = exporter.run()
                 mime = exporter.mime_type()
-        except ReportExportError as error:
+        except ReportExportTemplateError as error:
             logger.error("Project report failed for project %s and user %s: %s", project.id, self.request.user, error)
             messages.error(
                 self.request,

--- a/ghostwriter/users/tests/test_views.py
+++ b/ghostwriter/users/tests/test_views.py
@@ -340,7 +340,7 @@ class AvatarDownloadTest(TestCase):
 
         response = self.client_auth.get(self.uri)
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(response.get("Content-Disposition"), 'attachment; filename="fake.png"')
+        self.assertRegexpMatches(response.get("Content-Disposition"), r'^attachment; filename="fake[_0-9]*\.png"$')
 
         if os.path.exists(self.user_profile.avatar.path):
             os.remove(self.user_profile.avatar.path)


### PR DESCRIPTION
Add `ReportExportTemplateError` as an extension to `ReportExportError` for user-visible errors, and wrap all errors from the report writer in `ReportExportError`. This annotates all exceptions, even internal ones, with location information that can be used to diagnose issues.
