### PR TITLE
Remove ability to reorder findings

### DIFF
--- a/ghostwriter/reporting/templates/reporting/report_detail.html
+++ b/ghostwriter/reporting/templates/reporting/report_detail.html
@@ -222,9 +222,6 @@
           clicking the <span class="p-1 add-icon"></span> button in the results, or
           by clicking an autocomplete result above.</p>
 
-        <p class="mt-3">Drag and drop findings within a severity category to change its ordering. Edit
-          a finding to change its severity.</p>
-
         <button class="btn btn-primary icon add-icon col-3"
           onclick="attachBlankFinding()"
           data-toggle="tooltip"

--- a/ghostwriter/reporting/templates/snippets/report_findings_table.html
+++ b/ghostwriter/reporting/templates/snippets/report_findings_table.html
@@ -1,10 +1,8 @@
 {% load report_tags %}
 
 {% if report.reportfindinglink_set.all %}
-  <table id="findings-table" class="table table-sm table-hover"
-         findings-update-url="{% url 'reporting:update_report_findings' %}">
+  <table id="findings-table" class="table table-sm table-hover">
     <tr>
-      <th class="icon ol-list-icon text-center"></th>
       <th class="align-middle text-left">Finding</th>
       <th class="align-middle">CVSS Score</th>
       <th class="align-middle">
@@ -55,12 +53,6 @@
       {% if values.findings %}
         {% for finding in values.findings %}
           <tr id="finding_{{ finding.id }}" data-id="{{ finding.id }}" class="severity_row">
-            <td
-              class="holdme align-middle"
-              data-toggle="tooltip"
-              data-placement="top"
-              title="Click-n-drag to reposition"
-            ></td>
             <td class="align-middle text-left">
               <a id="delete-target-content-finding-{{ finding.id }}"
                 {% if finding.added_as_blank %}
@@ -232,76 +224,6 @@
       $('#confirm-delete-modal').attr('caller-id', $(this).attr('id'));
     });
   });
-
-  {% comment %} Configure table sorting by severity groups {% endcomment %}
-  {% if report.reportfindinglink_set %}
-    var update_url = $('#findings-table').attr('findings-update-url');
-    {% group_by_severity report.reportfindinglink_set.all as severity_groups %}
-    {% for group, values in severity_groups.items %}
-      var {{ values.tpl_name }}_sortable = Sortable.create({{ values.tpl_name }}_severity, {
-        items: 'tbody > tr',
-        group: 'severity.{{values.tpl_name}}',
-        animation: 150,
-        filter: '.severity-row-placeholder',
-        ghostClass: 'sortable-ghost',
-        handle: '.holdme',
-
-        // https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setData
-        setData: function (dataTransfer, dragEl) {
-          dataTransfer.setData('text/plain', dragEl.textContent); // `dataTransfer` object of HTML5 DragEvent
-        },
-
-        // Element is chosen
-        onChoose: function (event) {
-          event.oldIndex;
-        },
-
-        // Element is unchosen
-        onUnchoose: function (event) {
-        },
-
-        // Element dragging started
-        onStart: function (event) {
-          event.oldIndex;
-        },
-
-        // Called by any change to the list (add / update / remove)
-        onSort: function (event) {
-          // Code here triggers twice for the element if dragged to another group (two sorts)
-          [].forEach.call(event.item.parentNode.getElementsByClassName('severity_row'), function (el, _) {
-            let cell = el.getElementsByClassName('holdme')[0];
-          });
-        },
-
-        // Changed sorting within list
-        onUpdate: function (event) {
-          let weight = event.item.parentNode.getAttribute('severity-weight')
-          let positions = {{ values.tpl_name }}_sortable.toArray();
-          // Prep AJAX request with CSRF token
-          $.ajaxSetup({
-            beforeSend: function (xhr, settings) {
-              if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader('X-CSRFToken', csrftoken);
-              }
-            }
-          });
-          // Send AJAX POST request
-          $.ajax(update_url, {
-            type: 'POST',
-            data: {
-              'report': report_id,
-              'severity': event.item.parentNode.id,
-              'positions': JSON.stringify(positions),
-              'weight': weight
-            },
-            success: function (data) {
-              console.log(data);
-            }
-          });
-        },
-      });
-    {% endfor %}
-  {% endif %}
 
   {% comment %} Set finding status with AJAX {% endcomment %}
   $('.js-set-finding-status').each(function () {

--- a/ghostwriter/reporting/urls.py
+++ b/ghostwriter/reporting/urls.py
@@ -31,11 +31,6 @@ urlpatterns = [
 # URLs for AJAX requests – deletion and toggle views
 urlpatterns += [
     path(
-        "ajax/report/finding/order",
-        ghostwriter.reporting.views2.report_finding_link.ajax_update_report_findings,
-        name="update_report_findings",
-    ),
-    path(
         "ajax/report/observation/order",
         ghostwriter.reporting.views2.report_observation_link.ajax_update_report_observation_order,
         name="update_report_observations",


### PR DESCRIPTION
Due to the collab server limitations, we can't change the severity from outside the collab server without race conditions, so that part was disabled, but findings were still orderable within a severity. But this was confusing - people expected that dragging a finding would change its severity when it wasn't supported.

So for now, just remove it entirely. We may want to revert this change once we have a system to notify the collab editing server with django side updates.
