### PR TITLE
fix: Remove commented setting from base.py

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -338,7 +338,6 @@ SOCIALACCOUNT_LOGIN_ON_GET = env.bool("DJANGO_SOCIAL_ACCOUNT_LOGIN_ON_GET", Fals
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_LOGIN_METHODS = {"username"}
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
-# ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_SIGNUP_FIELDS = ['email*', 'username*', 'password1*', 'password2*']
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_EMAIL_VERIFICATION = env.bool("DJANGO_ACCOUNT_EMAIL_VERIFICATION", "mandatory")


### PR DESCRIPTION
### Description of the Change

Removed commented deprecated setting from Django base configuration file to clean up the codebase and improve maintainability. The commented setting was no longer relevant and its removal helps reduce confusion for developers working with the configuration.

### Release Notes

Not applicable
