### PR TITLE
fix(users): correct view name in RecoveryCodesView redirect

### DIFF
--- a/ghostwriter/users/views.py
+++ b/ghostwriter/users/views.py
@@ -279,4 +279,4 @@ class RecoveryCodesView(ViewRecoveryCodesView):
     def post(self, request, *args, **kwargs):
         # Only generate codes if the button was pressed
         flows.generate_recovery_codes(self.request)
-        return redirect(reverse("mfa_recovery_codes"))
+        return redirect(reverse("mfa_view_recovery_codes"))


### PR DESCRIPTION
### Identify the Bug

When generating new MFA recovery codes through the `RecoveryCodesView.post()` method, users are redirected to a Django server error page instead of the expected recovery codes view. This occurs because the `reverse()` call uses an incorrect view name `"mfa_recovery_codes"` that doesn't exist in the URL configuration, causing a `NoReverseMatch` exception and resulting in a 500 server error.

The correct view name should be `"mfa_view_recovery_codes"` to match the actual URL pattern defined in the application's URL configuration.


### Description of the Change

Fixed incorrect view name reference in the `RecoveryCodesView.post()` method. The `reverse()` call was using `"mfa_recovery_codes"` but should have been `"mfa_view_recovery_codes"` to properly redirect users after generating MFA recovery codes.

### Alternate Designs

No alternate designs considered - this was a straightforward bug fix to correct the view name reference to match the actual URL pattern name.

### Possible Drawbacks

None. This fix ensures proper redirection functionality that was previously broken due to the incorrect view name.

### Verification Process

1. Navigated to the MFA recovery codes page
2. Clicked the button to generate new recovery codes
3. Verified that the redirect now works correctly instead of throwing a NoReverseMatch error
4. Confirmed that recovery codes are generated and displayed properly after the redirect

### Release Notes

Fixed MFA recovery codes page redirect after generating
