### PR TITLE
Convert TinyMCE text align to TipTap

### DIFF
--- a/javascript/src/tiptap_gw/index.ts
+++ b/javascript/src/tiptap_gw/index.ts
@@ -2,7 +2,6 @@
 // change the schema.
 
 import StarterKit from "@tiptap/starter-kit";
-import TextAlign from "@tiptap/extension-text-align";
 import Table from "@tiptap/extension-table";
 import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
@@ -23,6 +22,7 @@ import { TableWithCaption, TableCaption, GwTableCell } from "./table";
 import { HeadingWithId } from "./heading";
 import Color from "./color";
 import Link from "./link";
+import TextAlign from "./text_align";
 
 const EXTENSIONS: Extensions = [
     StarterKit.configure({

--- a/javascript/src/tiptap_gw/text_align.ts
+++ b/javascript/src/tiptap_gw/text_align.ts
@@ -1,0 +1,27 @@
+// Extension of tiptap's builtin alignment extension that also picks up TinyMCE's alignment classes
+
+import TTTextAlign from "@tiptap/extension-text-align";
+
+const TextAlign = TTTextAlign.extend({
+    addGlobalAttributes() {
+        const attrs = TTTextAlign.config.addGlobalAttributes!.call(this);
+        attrs[0].attributes.textAlign!.parseHTML = (el) => {
+            let align = el.style.textAlign;
+            if (align !== "" && !this.options.alignments.includes(align))
+                align = "";
+
+            // If no tiptap-specified alignment, check TinyMCE classes.
+            if (align === "") {
+                for (const cls of this.options.alignments) {
+                    if (el.classList.contains(cls)) {
+                        align = cls;
+                        break;
+                    }
+                }
+            }
+            return align === "" ? this.options.defaultAlignment : align;
+        };
+        return attrs;
+    },
+});
+export default TextAlign;


### PR DESCRIPTION
TinyMCE uses class names, whereas TipTap uses the text-align style. This patch extends tiptap's text alignment extension to parse TinyMCE's classes.

(cherry picked from commit c66605ab8df71eae55b3f757d10bb24f1180b19e)
