### PR TITLE
config(mfa): disable passkey login by default

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -332,7 +332,7 @@ MFA_SUPPORTED_TYPES = ["totp", "webauthn", "recovery_codes"]
 
 # Enable support for logging in using a (WebAuthn) passkey.
 # https://docs.allauth.org/en/dev/mfa/webauthn.html
-MFA_PASSKEY_LOGIN_ENABLED = True
+MFA_PASSKEY_LOGIN_ENABLED = False
 
 # django-allauth-mfa forms
 MFA_FORMS = {

--- a/ghostwriter/templates/account/login.html
+++ b/ghostwriter/templates/account/login.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load account socialaccount %}
+{% load allauth %}
 {% load crispy_forms_tags %}
 
 {% block title %}Sign In{% endblock %}
@@ -62,10 +63,12 @@
   </form>
 
   <!-- WebAuthn/Passkey Login Section -->
+  {% if PASSKEY_LOGIN_ENABLED %}
   <div class="mt-3">
     <button form="mfa_login" type="button" id="passkey_login" class="btn btn-outline-primary">
       {% trans "Sign in with a Passkey" %}
     </button>
     {% include "mfa/webauthn/snippets/login_script.html" with button_id="passkey_login" %}
   </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Issue

N/A

### Description of the Change

This pull request disables the WebAuthn passkey login feature by default while maintaining support for WebAuthn security keys as a second-factor authentication method. The changes include:

- **Configuration Update**: Set `MFA_PASSKEY_LOGIN_ENABLED` to `False` in `config/settings/base.py`, which disables passwordless passkey authentication while preserving WebAuthn support for multi-factor authentication

- **Template Conditional**: Added conditional rendering in `ghostwriter/templates/account/login.html` to hide the "Sign in with a Passkey" button when passkey login is disabled, preventing users from attempting to use unavailable functionality

- **Import Addition**: Added `{% load allauth %}` to the login template to ensure access to the `PASSKEY_LOGIN_ENABLED` context variable

The change separates passwordless passkey login from traditional WebAuthn security key usage for MFA. Users can still register and use WebAuthn security keys as a second factor, but cannot use passkeys as a primary login method.

### Alternate Designs

Alternative approaches considered:

1. **Complete removal of WebAuthn support**: This would have eliminated both passkey login and security key MFA, which was not desirable as WebAuthn security keys provide strong MFA protection

2. **Remove passkey UI without configuration change**: Simply hiding the button without the configuration change could lead to confusion if the feature was inadvertently enabled through environment variables

3. **Per-user passkey toggle**: Allow individual users to enable/disable passkey login, but this adds complexity and potential security management issues

The chosen approach provides a clean server-side configuration control with appropriate UI updates, allowing administrators to easily enable passkey login in the future if desired.

### Possible Drawbacks

- Users who may have expected passkey login functionality will not see the option on the login page
- If passkey login is later re-enabled, existing users will need to be notified of the feature availability
- The conditional template logic adds a small amount of complexity to the login template

### Verification Process

To verify this change:

1. **Verify Configuration**:
   - Confirm `MFA_PASSKEY_LOGIN_ENABLED = False` in `config/settings/base.py`
   - Rebuild and restart the Django application to apply settings changes:
     ```bash
     alias gwbuild='docker compose -f local.yml build  # Build the Docker containers'
     alias gwrsdj='docker compose -f local.yml restart django   # Restart the Django service'
     gwbuild && gwrsdj
     ```

2. **Test Login Page**:
   - Navigate to the login page at `/accounts/login/`
   - Verify the "Sign in with a Passkey" button is NOT displayed
   - Confirm standard username/password login still functions correctly

3. **Test MFA with WebAuthn Security Keys**:
   - Log in with a user account that has MFA enabled
   - Navigate to MFA settings page
   - Verify the ability to add/manage WebAuthn security keys as a second factor
   - Test authentication using a registered security key
   - Confirm security key MFA functionality remains intact

4. **Test Enabling Passkey Login**:
   - Set `MFA_PASSKEY_LOGIN_ENABLED = True` in settings
   - Restart application with `gwbuild && gwrsdj`
   - Verify "Sign in with a Passkey" button appears on login page
   - Confirm the conditional rendering works in both states

5. **Verify Template Loading**:
   - Check that the `{% load allauth %}` tag properly loads without errors
   - Confirm the `PASSKEY_LOGIN_ENABLED` variable is accessible in the template context

### Release Notes

Disabled WebAuthn passkey login by default; WebAuthn security keys remain available for multi-factor authentication
