### PR TITLE
Changed `cvss_score` to return `0.0` if empty

### DIFF
--- a/ghostwriter/modules/custom_serializers.py
+++ b/ghostwriter/modules/custom_serializers.py
@@ -278,7 +278,7 @@ class FindingLinkSerializer(TaggitSerializer, CustomModelSerializer):
 
     def get_cvss_score(self, obj):
         # If the score is empty, return `0.0` to ensure the value is always a float value
-        if obj.cvss_score is "" or obj.cvss_score is None:
+        if obj.cvss_score in ("", None):
             return 0.0
         return obj.cvss_score
 


### PR DESCRIPTION
This fixes #736 by making empty `cvss_score` values return as `0.0`. The values are not consistently float values (either `0.0` or a float score). Generating a report with the example `sort` filter was successful.