### PR TITLE
fix(rolodex): spelling error

### DIFF
--- a/ghostwriter/rolodex/templates/rolodex/project_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/project_detail.html
@@ -1122,7 +1122,7 @@
       {% endif %}
 
       <div id="collab_notes" class="tab-pane">
-        <h4>Collaborative Nodes</h4>
+        <h4>Collaborative Notes</h4>
         <hr />
 
         <div id="collab_notes_container">


### PR DESCRIPTION
### Issue

N/A

### Description of the Change

This change corrects a spelling error in the project detail template. The heading "Collaborative Nodes" has been changed to "Collaborative Notes" to accurately reflect the section's purpose of displaying collaborative notes rather than nodes.

This is a simple text correction in the HTML template file `ghostwriter/rolodex/templates/rolodex/project_detail.html`.

### Alternate Designs

No alternate designs were considered as this is a straightforward spelling correction.

### Possible Drawbacks

None. This is a cosmetic fix that improves accuracy and user experience.

### Verification Process

- Verified the spelling error existed in the template at line 1125
- Confirmed the change corrects "Nodes" to "Notes"
- Reviewed the context to ensure "Collaborative Notes" is the intended meaning
- No functional changes were made, only text content

### Release Notes

Fixed spelling error in project detail page: "Collaborative Nodes" changed to "Collaborative
