### PR TITLE
Fix rich text editor buttons not rerendering

### DIFF
--- a/javascript/src/frontend/admin_tiptap.tsx
+++ b/javascript/src/frontend/admin_tiptap.tsx
@@ -1,34 +1,31 @@
-import {
-    Editor,
-    EditorProvider,
-    useCurrentEditor,
-    useEditor,
-    useEditorState,
-} from "@tiptap/react";
+import { Editor, EditorContent, useEditor } from "@tiptap/react";
 import EXTENSIONS from "../tiptap_gw";
-import { Toolbar } from "./collab_forms/rich_text_editor";
 import { useCallback, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { Toolbar } from "./collab_forms/rich_text_editor";
 
 function RichTextEditor(props: { name: string; initial: string; id: string }) {
+    const editor = useEditor({
+        extensions: EXTENSIONS,
+        content: props.initial,
+    });
+
     return (
         <div className="collab-editor">
-            <EditorProvider
-                extensions={EXTENSIONS}
-                slotBefore={<Toolbar />}
-                content={props.initial}
-            >
-                <HtmlInputElement
-                    name={props.name}
-                    initial={props.initial}
-                    id={props.id}
-                />
-            </EditorProvider>
+            <Toolbar editor={editor} />
+            <EditorContent editor={editor} />
+            <HtmlInputElement
+                editor={editor}
+                name={props.name}
+                initial={props.initial}
+                id={props.id}
+            />
         </div>
     );
 }
 
 function HtmlInputElement(props: {
+    editor: Editor | null;
     name: string;
     initial: string;
     id: string;
@@ -41,13 +38,12 @@ function HtmlInputElement(props: {
         [setHtml]
     );
 
-    const { editor } = useCurrentEditor();
     useEffect(() => {
-        editor?.on("update", updateHtml);
+        props.editor?.on("update", updateHtml);
         return () => {
-            editor?.off("update", updateHtml);
+            props.editor?.off("update", updateHtml);
         };
-    }, [editor]);
+    }, [props.editor]);
 
     return <input type="hidden" name={props.name} value={html} id={props.id} />;
 }

--- a/javascript/src/frontend/collab_forms/rich_text_editor/caption.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/caption.tsx
@@ -1,15 +1,17 @@
 import { useId, useState } from "react";
 import ReactModal from "react-modal";
-import { useCurrentEditor } from "@tiptap/react";
+import { Editor, useEditorState } from "@tiptap/react";
 import { MenuItem } from "@szhsin/react-menu";
 
-export default function CaptionButton() {
-    const editor = useCurrentEditor().editor!;
+export default function CaptionButton({ editor }: { editor: Editor }) {
     const [modalOpen, setModalOpen] = useState(false);
     const [refName, setRefName] = useState("");
     const fieldId = useId();
 
-    const enabled = editor.can().setCaption("refname");
+    const enabled = useEditorState({
+        editor,
+        selector: ({ editor }) => editor.can().setCaption("refname"),
+    });
 
     return (
         <>

--- a/javascript/src/frontend/collab_forms/rich_text_editor/color.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/color.tsx
@@ -4,6 +4,7 @@ import { Editor } from "@tiptap/core";
 import { useState } from "react";
 import ReactModal from "react-modal";
 import { Sketch } from "@uiw/react-color";
+import { useEditorState } from "@tiptap/react";
 
 export type ColorModalMode = null | "new" | "edit";
 export function ColorModal(props: {
@@ -74,13 +75,19 @@ export default function ColorButton({ editor }: { editor: Editor }) {
     const [modalMode, setModalMode] = useState<null | "new" | "edit">(null);
     const [formColor, setFormColor] = useState<string>("#f00");
 
-    const enabled = editor
-        .can()
-        .chain()
-        .focus()
-        .setColor({ color: "#fff" })
-        .run();
-    const active = editor.isActive("color");
+    const { enabled, active } = useEditorState({
+        editor,
+        selector: ({ editor }) => {
+            const enabled = editor
+                .can()
+                .chain()
+                .focus()
+                .setColor({ color: "#fff" })
+                .run();
+            const active = editor.isActive("color");
+            return { enabled, active };
+        },
+    });
 
     return (
         <>

--- a/javascript/src/frontend/collab_forms/rich_text_editor/evidence/index.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/evidence/index.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Editor } from "@tiptap/core";
 import { useCallback, useEffect, useState } from "react";
 import EvidenceModal from "./modal";
+import { useEditorState } from "@tiptap/react";
 
 export default function EvidenceButton({ editor }: { editor: Editor }) {
     // null = closed, "new" = inserting, number = editing with the existing ID as the number
@@ -10,13 +11,19 @@ export default function EvidenceButton({ editor }: { editor: Editor }) {
         null
     );
 
-    const enabled = editor
-        .can()
-        .chain()
-        .focus()
-        .setEvidence({ id: 1234 })
-        .run();
-    const active = editor.isActive("evidence");
+    const { enabled, active } = useEditorState({
+        editor,
+        selector: ({ editor }) => {
+            const enabled = editor
+                .can()
+                .chain()
+                .focus()
+                .setEvidence({ id: 1234 })
+                .run();
+            const active = editor.isActive("evidence");
+            return { enabled, active };
+        },
+    });
 
     const applyCb = useCallback(
         (id: number | null) => {

--- a/javascript/src/frontend/collab_forms/rich_text_editor/heading.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/heading.tsx
@@ -1,16 +1,18 @@
 import { useId, useState } from "react";
 import { HeadingWithId } from "../../../tiptap_gw/heading";
 import ReactModal from "react-modal";
-import { useCurrentEditor } from "@tiptap/react";
+import { Editor, useEditorState } from "@tiptap/react";
 import { MenuItem } from "@szhsin/react-menu";
 
-export default function HeadingIdButton() {
-    const editor = useCurrentEditor().editor!;
+export default function HeadingIdButton({ editor }: { editor: Editor }) {
     const [modalOpen, setModalOpen] = useState(false);
     const [bookmark, setBookmark] = useState("");
     const fieldId = useId();
 
-    const enabled = editor.can().setHeadingBookmark("example");
+    const enabled = useEditorState({
+        editor,
+        selector: ({ editor }) => editor.can().setHeadingBookmark("example"),
+    });
 
     return (
         <>

--- a/javascript/src/frontend/collab_forms/rich_text_editor/link.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/link.tsx
@@ -1,22 +1,28 @@
 import { faLink } from "@fortawesome/free-solid-svg-icons/faLink";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Editor } from "@tiptap/core";
+import { useEditorState } from "@tiptap/react";
 import { useId, useState } from "react";
 import ReactModal from "react-modal";
 
-export default function LinkButton(props: { editor: Editor }) {
-    const { editor } = props;
+export default function LinkButton({ editor }: { editor: Editor }) {
     const [modalMode, setModalMode] = useState<null | "new" | "edit">(null);
     const [formUrl, setFormUrl] = useState("");
     const urlId = useId();
 
-    const enabled = editor
-        .can()
-        .chain()
-        .focus()
-        .setLink({ href: "https://example.com" })
-        .run();
-    const active = editor.isActive("link");
+    const { enabled, active } = useEditorState({
+        editor,
+        selector: ({ editor }) => {
+            const enabled = editor
+                .can()
+                .chain()
+                .focus()
+                .setLink({ href: "https://example.com" })
+                .run();
+            const active = editor.isActive("link");
+            return { enabled, active };
+        },
+    });
 
     return (
         <>

--- a/javascript/src/frontend/collab_forms/rich_text_editor/table.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/table.tsx
@@ -1,17 +1,20 @@
 import { useId, useState } from "react";
 import ReactModal from "react-modal";
-import { useCurrentEditor } from "@tiptap/react";
+import { Editor, useEditorState } from "@tiptap/react";
 import { MenuItem } from "@szhsin/react-menu";
 import { GwTableCell, TableCaption } from "../../../tiptap_gw/table";
 import { ColorModal, ColorModalMode } from "./color";
 
-export function TableCaptionBookmarkButton() {
-    const editor = useCurrentEditor().editor!;
+export function TableCaptionBookmarkButton({ editor }: { editor: Editor }) {
     const [modalOpen, setModalOpen] = useState(false);
     const [bookmark, setBookmark] = useState("");
     const fieldId = useId();
 
-    const enabled = editor.can().setTableCaptionBookmark("example");
+    const enabled = useEditorState({
+        editor,
+        selector: ({ editor }) =>
+            editor.can().setTableCaptionBookmark("example"),
+    });
 
     return (
         <>
@@ -85,8 +88,7 @@ export function TableCaptionBookmarkButton() {
     );
 }
 
-export function TableCellBackgroundColor() {
-    const editor = useCurrentEditor().editor!;
+export function TableCellBackgroundColor({ editor }: { editor: Editor }) {
     const [modalMode, setModalMode] = useState<ColorModalMode>(null);
     const [formColor, setFormColor] = useState<string>("#f00");
 

--- a/javascript/src/tiptap_gw/case_change.ts
+++ b/javascript/src/tiptap_gw/case_change.ts
@@ -57,7 +57,9 @@ const CaseChange = Extension.create({
                         );
                     }
 
-                    if (inserts.length === 0) return false;
+                    if (inserts.length === 0) {
+                        return false;
+                    }
 
                     for (const [oldText, from, to] of inserts) {
                         let newText;


### PR DESCRIPTION
Tiptap v3 does not seem to rerender components on editor changes, causing some of the formatting buttons to be disabled arbitrairly. This patch uses the `useEditorState` hook to retreieve updates to editor state, which does cause rerenders.
