### PR TITLE
Move bloodhound_heading_offset to ExportBase

### DIFF
--- a/ghostwriter/modules/reportwriter/base/base.py
+++ b/ghostwriter/modules/reportwriter/base/base.py
@@ -174,6 +174,12 @@ class ExportBase:
             ext = self.extension()
         return report_name.strip() + "." + ext
 
+    def bloodhound_heading_offset(self) -> int:
+        """
+        Number of levels to offset headers in the descriptions from BloodHound data. Default is zero.
+        """
+        return 0
+
 def _replace_filename_chars(name):
     """Remove illegal characters from the report name."""
     name = name.replace("–", "-")

--- a/ghostwriter/modules/reportwriter/project/base.py
+++ b/ghostwriter/modules/reportwriter/project/base.py
@@ -24,9 +24,6 @@ class ExportProjectBase(ExportBase):
     def serialize_object(self, object):
         return FullProjectSerializer(object).data
 
-    def bloodhound_heading_offset(self) -> int:
-        return 0
-
     def map_rich_texts(self):
         base_context = copy.deepcopy(self.data)
         rich_text_context = ChainMap(ExportProjectBase.rich_text_jinja_overlay(self.data), base_context)

--- a/ghostwriter/modules/reportwriter/report/base.py
+++ b/ghostwriter/modules/reportwriter/report/base.py
@@ -39,9 +39,6 @@ class ExportReportBase(ExportBase):
             exclude=excludes,
         ).data
 
-    def bloodhound_heading_offset(self) -> int:
-        return 0
-
     def severity_rich_text(self, text: str, severity_color: str) -> str | DocxRichText:
         """
         Creates an exporter specific rich text object for some text related to finding severity.


### PR DESCRIPTION
Makes the inheritance less confusing. The default implementations were put on `ExportReport` and `ExportProject` since the offset isn't relevant to other types, but causes a weird inheritance issue since `ExportDocx` overrides it.
