### PR TITLE
Fix collab editor sometimes not loading

### DIFF
--- a/javascript/src/frontend/collab_forms/rich_text_editor/index.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/index.tsx
@@ -112,7 +112,7 @@ export function Toolbar(props: {
     extra?: (editor: Editor) => React.ReactNode;
 }) {
     const editor = props.editor;
-    if (!editor) return null;
+    if (!editor || editor.isDestroyed) return null;
     return (
         <div className="control-group">
             <div className="button-group">


### PR DESCRIPTION
The toolbar's button active tests would sometimes error out if somehow ran before the editor has mounted. This adds a check to the editor rendering to prevent it from rendering if the editor is not mounted.
