### PR TITLE
Fix error when accessing domains in admin panel

### DIFF
--- a/ghostwriter/shepherd/admin.py
+++ b/ghostwriter/shepherd/admin.py
@@ -167,7 +167,7 @@ class DomainAdmin(ImportExportModelAdmin):
                 )
             },
         ),
-        ("Misc", {"fields": ("note",)}),
+        ("Misc", {"fields": ("description",)}),
     )
 
     def get_queryset(self, request):


### PR DESCRIPTION
Admin panel was referencing "note" instead of "description".
