### PR TITLE
Fix issue with cloud infra on reports

### DIFF
--- a/ghostwriter/modules/reportwriter/project/base.py
+++ b/ghostwriter/modules/reportwriter/project/base.py
@@ -171,7 +171,7 @@ class ExportProjectBase(ExportBase):
             if server["description"]:
                 server["description_rt"] = ex.create_lazy_template(
                     f"the description of cloud server {server.get('name')}",
-                    domain["description"],
+                    server["description"],
                     rich_text_context,
                 )
         for server in base_context["infrastructure"]["servers"]:


### PR DESCRIPTION
Copy+paste error where cloud infra descriptions had the wrong value and potentially would result in an `UnboundLocalError`
