### PR TITLE
Fix evidence images in rich text fields

### DIFF
--- a/ghostwriter/commandcenter/templates/collab_editing/attrs_snippet.html
+++ b/ghostwriter/commandcenter/templates/collab_editing/attrs_snippet.html
@@ -11,6 +11,5 @@
 
 <script type="text/plain" id="graphql-path">/v1/graphql</script>
 <script type="text/plain" id="graphql-auth">{{collab_jwt}}</script>
-<script type="text/plain" id="graphql-media-url">{{collab_media_url}}</script>
 
 <link rel="stylesheet" href="{% static 'assets/collab_common.css' %}">

--- a/javascript/src/frontend/graphql/evidence.tsx
+++ b/javascript/src/frontend/graphql/evidence.tsx
@@ -47,14 +47,12 @@ export function usePageEvidence(): Evidences | null {
     const evidences = data?.evidence;
     if (evidences === null || evidences === undefined) return null;
 
-    const mediaUrl = document.getElementById("graphql-media-url")!.innerHTML;
     const uploadUrl = document.getElementById(
         "graphql-evidence-upload-url"
     )!.innerHTML;
 
     return {
         evidence: evidences,
-        mediaUrl,
         uploadUrl,
         poll,
     };

--- a/javascript/src/tiptap_gw/evidence.tsx
+++ b/javascript/src/tiptap_gw/evidence.tsx
@@ -90,7 +90,6 @@ export type Evidence = {
 
 export type Evidences = {
     evidence: Evidence[];
-    mediaUrl: string;
     uploadUrl: string;
     poll: () => Promise<void>;
 };
@@ -122,7 +121,7 @@ function EvidenceView(props: NodeViewProps) {
         evidence.document.endsWith(".jpg") ||
         evidence.document.endsWith(".jpeg")
     ) {
-        const url = ghostwriterEvidences.mediaUrl + evidence["document"];
+        const url = "/reporting/evidence/download/" + evidence.id;
         img = (
             <>
                 <img src={url} onClick={() => setLightboxOpen(true)} />


### PR DESCRIPTION
It was using the MEDIA_URL path, which was disabled for evidences because there is no RBAC on it. This updates the rich text editor to use the new, secured endpoint.

Thank you to @domwhewell-sage on the Ghostwriter Slack for reporting