### PR TITLE
Fix setuptools

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -23,7 +23,7 @@ RUN apk --no-cache add build-base curl \
     && apk --no-cache add cargo \
     # Git for installing packages from GitHub
     && apk --no-cache add git \
-    && pip install --no-cache-dir -U setuptools pip
+    && pip install --no-cache-dir -U pip
 
 COPY ./requirements /requirements
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,7 @@ argon2-cffi==23.1.0  # https://github.com/hynek/argon2_cffi
 redis==5.0.8  # https://github.com/antirez/redis
 uvicorn[standard]==0.38.0  # https://github.com/Kludex/uvicorn
 tzdata==2024.1
+setuptools<81  # Pin to <81 to preserve pkg_resources for docxcompose dependency
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This pins `setuptools` to < v81 to preserve the `pkg_resources` dependency that v81+ deprecated on February 9th. The `pkg_resources` is still used by `docxcompose`, an non-optional dependency for `docxtpl`. This is not a permanent solution, but it is a necessary change until we can evaluate how to proceed with `docxtpl` and `docxcompose`.