### PR TITLE
Feature: Narrative outlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `recording` tag added when a recording is uploaded, removed when the recording is deleted
   * Tags can be used for filtering log entries and visual identification
 
+* **Build a Narrative Outline from Log Entries**: Construct an outline for a report narrative based on tagged log entries
+  * This is useful for quickly generating a narrative outline to kickstart a report draft
+  * Added a button to the collaborative editor to insert a narrative outline based on activity logs
+  * The action includes any log entries tagged with `evidence` or `report`
+  * Each line includes the start date and time, tool used, target, and comments
+  * The action also inserts evidence objects below each line for any evidence linked with that entry
+
 ### Changed
 
 * **New User Interface for Operation Logs**: Replaced the table view for operation logs with two pane interface (Closes #831)
@@ -39,9 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Text Evidence Previews**: Text evidence now has previews in the collaborative editor like image evidence
 
-* **Pasting Images into Collab Editor**: You can now paste an image file or screenshot in your clipboard into a collaborative editor field
+* **Pasting Images into Collaborative Editor**: You can now paste an image file or screenshot in your clipboard into a collaborative editor field
   * The paste will automatically trigger the modal window for uploading your evidence
   * Your filename will be the default friendly name for the upload
+
+* Report names in the sidebar now also include the parent project's codename to aid in identification
 
 ### Security
 

--- a/ghostwriter/home/templatetags/custom_tags.py
+++ b/ghostwriter/home/templatetags/custom_tags.py
@@ -70,23 +70,23 @@ def get_assignment_data(request):
     with an individual :model:`users.User` and return a list of unique
     :model:`rolodex.Project` entries and a list of unique :model:`reporting.Report` entries.
     """
-    active_projects = []
-    active_reports = []
-
     user_assignments = (
         ProjectAssignment.objects.select_related("project")
         .filter(Q(operator=request.user) & Q(project__complete=False))
         .order_by("project__end_date")
     )
+    active_projects = []
+    project_ids = []
     for assignment in user_assignments:
         if assignment.project not in active_projects:
             active_projects.append(assignment.project)
+            project_ids.append(assignment.project_id)
 
-    for active_project in active_projects:
-        reports = Report.objects.filter(Q(project=active_project) & Q(complete=False))
-        for report in reports:
-            if report not in active_reports:
-                active_reports.append(report)
+    active_reports = list(
+        Report.objects.select_related("project")
+        .filter(project_id__in=project_ids, complete=False)
+        .order_by("project__end_date", "title", "id")
+    )
     return active_projects, active_reports
 
 

--- a/ghostwriter/home/tests/test_views.py
+++ b/ghostwriter/home/tests/test_views.py
@@ -114,6 +114,16 @@ class TemplateTagTests(TestCase):
         self.assertEqual(projects[0], self.project)
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0], self.report)
+        self.assertEqual(reports[0].project, self.project)
+
+    def test_get_assignment_data_prefetches_report_projects(self):
+        response = self.client_auth.get(self.uri)
+        request = response.wsgi_request
+
+        with self.assertNumQueries(2):
+            projects, reports = custom_tags.get_assignment_data(request)
+            self.assertEqual(projects[0].codename, self.project.codename)
+            self.assertEqual(reports[0].project.codename, self.project.codename)
 
         result = custom_tags.settings_value("DATE_FORMAT")
         self.assertEqual(result, settings.DATE_FORMAT)

--- a/ghostwriter/oplog/forms.py
+++ b/ghostwriter/oplog/forms.py
@@ -276,7 +276,11 @@ class OplogEvidenceForm(forms.ModelForm):
         friendly_name = cleaned_data.get("friendly_name")
         report = cleaned_data.get("report")
         if friendly_name and report:
-            qs = Evidence.objects.filter(friendly_name=friendly_name, report=report)
+            # TODO: Remove finding-level evidence compatibility after PR #790 lands
+            # For now, oplog uploads must reject any duplicate friendly name across all
+            # evidence associated with the report so {{.ref ...}} references stay unique
+            qs = report.all_evidences().filter(friendly_name=friendly_name)
+            # qs = Evidence.objects.filter(friendly_name=friendly_name, report=report)
             if self.instance.pk:
                 qs = qs.exclude(pk=self.instance.pk)
             if qs.exists():

--- a/ghostwriter/oplog/tests/test_forms.py
+++ b/ghostwriter/oplog/tests/test_forms.py
@@ -7,12 +7,14 @@ from django.test import TestCase
 
 # Ghostwriter Libraries
 from ghostwriter.factories import (
+    EvidenceOnFindingFactory,
     EvidenceOnReportFactory,
     OplogEntryFactory,
     OplogFactory,
     ProjectAssignmentFactory,
     ProjectFactory,
     ReportFactory,
+    ReportFindingLinkFactory,
     UserFactory,
 )
 from ghostwriter.modules.model_utils import to_dict
@@ -207,6 +209,20 @@ class OplogEvidenceFormTests(TestCase):
             files={"document": file},
         )
         self.assertTrue(form.is_valid())
+
+    def test_clean_rejects_duplicate_friendly_name_from_finding_evidence(self):
+        """Finding-level evidence on the same report also blocks duplicate friendly names."""
+        finding = ReportFindingLinkFactory(report=self.report)
+        EvidenceOnFindingFactory(friendly_name="Duplicate Evidence", finding=finding)
+        file = SimpleUploadedFile("evidence.png", b"img data", content_type="image/png")
+        form = OplogEvidenceForm(
+            project=self.project,
+            data={"friendly_name": "Duplicate Evidence", "report": self.report.pk, "caption": "Test"},
+            files={"document": file},
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("__all__", form.errors)
+        self.assertIn("friendly name already exists", form.errors["__all__"][0])
 
     def test_clean_allows_update_existing_instance(self):
         """Updating an existing evidence instance does not falsely trigger the duplicate check."""

--- a/ghostwriter/oplog/tests/test_views.py
+++ b/ghostwriter/oplog/tests/test_views.py
@@ -6,6 +6,7 @@ import logging
 import os
 import zipfile
 from datetime import datetime
+from unittest.mock import patch
 
 # Django Imports
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -1265,6 +1266,22 @@ class OplogRecordingUploadViewTests(TestCase):
         self.assertEqual(OplogEntryRecording.objects.filter(oplog_entry=self.entry).count(), 1)
         self.entry.refresh_from_db()
         self.assertIn("recording", list(self.entry.tags.names()))
+
+    def test_failed_replacement_preserves_existing_recording(self):
+        """A failed replacement must not remove the existing recording."""
+        from ghostwriter.oplog.models import OplogEntryRecording
+
+        self.client_auth.post(self.uri, {"recording_file": self._cast_file("first.cast")})
+        original_recording = OplogEntryRecording.objects.get(oplog_entry=self.entry)
+        original_name = original_recording.recording_file.name
+
+        with patch("ghostwriter.oplog.views.OplogEntryRecording.save", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                self.client_auth.post(self.uri, {"recording_file": self._cast_file("second.cast")})
+
+        preserved_recording = OplogEntryRecording.objects.get(oplog_entry=self.entry)
+        self.assertEqual(preserved_recording.pk, original_recording.pk)
+        self.assertEqual(preserved_recording.recording_file.name, original_name)
 
     def test_manager_access(self):
         """Test that a manager can upload a recording without a project assignment."""

--- a/ghostwriter/oplog/views.py
+++ b/ghostwriter/oplog/views.py
@@ -940,21 +940,36 @@ class OplogRecordingUpload(RoleBasedAccessControlMixin, View):
         filename_lower = recording_file.name.lower()
         if not (filename_lower.endswith(".cast") or filename_lower.endswith(".cast.gz")):
             return JsonResponse({"result": "error", "message": "Only .cast and .cast.gz files are accepted."}, status=400)
-        # Replace any existing recording
+
+        # Update an existing recording in place when possible so a failed replacement
+        # does not delete the current attachment before the new file is safely saved.
         try:
-            entry.recording.delete()
+            recording = entry.recording
         except OplogEntryRecording.DoesNotExist:
-            pass
+            recording = OplogEntryRecording(oplog_entry=entry)
+
+        old_recording_name = ""
+        old_recording_storage = None
+        if recording.pk and recording.recording_file:
+            # Keep a handle to the previous file and only delete it after the new save
+            # commits successfully. This avoids data loss on transient upload failures.
+            old_recording_name = recording.recording_file.name
+            old_recording_storage = recording.recording_file.storage
 
         # Extract searchable text from the cast file before saving
         file_content = recording_file.read()
         recording_file.seek(0)
         recording_text, text_warning = extract_cast_text(file_content)
 
-        recording = OplogEntryRecording(oplog_entry=entry, uploaded_by=request.user)
+        recording.uploaded_by = request.user
         recording.recording_file = recording_file
         recording.recording_text = recording_text
-        recording.save()
+        with transaction.atomic():
+            recording.save()
+            if old_recording_name and old_recording_name != recording.recording_file.name:
+                # Delay file deletion until after commit so the old recording remains
+                # available if saving the replacement raises or the transaction rolls back.
+                transaction.on_commit(lambda: old_recording_storage.delete(old_recording_name))
         response = {
             "result": "success",
             "recording_url": reverse("oplog:oplog_entry_recording_download", kwargs={"pk": recording.pk}),

--- a/ghostwriter/reporting/templates/reporting/report_update_extra_field.html
+++ b/ghostwriter/reporting/templates/reporting/report_update_extra_field.html
@@ -45,6 +45,8 @@
 
 {%  block morescripts %}
     {{ block.super }}
+    {{ report_oplogs|json_script:"report-oplog-options" }}
     <script type="text/plain" id="graphql-evidence-report-id">{{object.id}}</script>
     <script type="text/plain" id="graphql-evidence-upload-url">{% url 'reporting:upload_evidence' 'report' object.id %}</script>
+    <script type="text/plain" id="report-oplog-outline-url">{% url 'reporting:report_generate_oplog_outline' object.id %}</script>
 {% endblock %}

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2,10 +2,11 @@
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Django Imports
 from django.contrib.messages import get_messages
+from django.conf import settings
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils.dateformat import format as dateformat
@@ -29,6 +30,9 @@ from ghostwriter.factories import (
     GenerateMockProject,
     LocalFindingNoteFactory,
     ObservationFactory,
+    OplogEntryEvidenceFactory,
+    OplogEntryFactory,
+    OplogFactory,
     ProjectAssignmentFactory,
     ProjectFactory,
     ProjectTargetFactory,
@@ -1177,6 +1181,143 @@ class ReportDetailViewTests(TestCase):
         response = self.client_mgr.get(self.uri)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "reporting/report_detail.html")
+
+
+class ReportOplogOutlineGenerateTests(TestCase):
+    """Collection of tests for :view:`reporting.ReportOplogOutlineGenerate`."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.report = ReportFactory()
+        cls.oplog = OplogFactory(project=cls.report.project, name="Primary Log")
+        cls.other_report = ReportFactory()
+        cls.other_oplog = OplogFactory(project=cls.other_report.project, name="Other Log")
+        cls.user = UserFactory(password=PASSWORD)
+        cls.mgr_user = UserFactory(password=PASSWORD, role="manager")
+        cls.uri = reverse(
+            "reporting:report_generate_oplog_outline",
+            kwargs={"pk": cls.report.pk},
+        )
+        cls.failure_redirect_uri = reverse("home:dashboard")
+
+    def setUp(self):
+        self.client = Client()
+        self.client_auth = Client()
+        self.client_mgr = Client()
+        self.assertTrue(self.client_auth.login(username=self.user.username, password=PASSWORD))
+        self.assertTrue(self.client_mgr.login(username=self.mgr_user.username, password=PASSWORD))
+
+    def test_view_requires_permission(self):
+        response = self.client.post(
+            self.uri,
+            data=json.dumps({"oplog_id": self.oplog.pk}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client_auth.post(
+            self.uri,
+            data=json.dumps({"oplog_id": self.oplog.pk}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, self.failure_redirect_uri)
+
+    def test_view_rejects_oplog_from_another_project(self):
+        response = self.client_mgr.post(
+            self.uri,
+            data=json.dumps({"oplog_id": self.other_oplog.pk}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_view_returns_empty_list_when_no_matching_entries_exist(self):
+        response = self.client_mgr.post(
+            self.uri,
+            data=json.dumps({"oplog_id": self.oplog.pk}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["blocks"], [])
+
+    def test_view_generates_expected_outline_lines(self):
+        first_start = datetime(2024, 5, 1, 14, 0, 0, tzinfo=timezone.utc)
+        second_start = datetime(2024, 5, 1, 15, 30, 0, tzinfo=timezone.utc)
+
+        entry_one = OplogEntryFactory(
+            oplog_id=self.oplog,
+            start_date=first_start,
+            tool="Nmap",
+            source_ip="10.0.0.10",
+            dest_ip="10.0.0.20",
+            comments="<p>Initial foothold confirmed.</p>",
+            tags=["report"],
+        )
+        entry_two = OplogEntryFactory(
+            oplog_id=self.oplog,
+            start_date=second_start,
+            tool="",
+            source_ip="",
+            dest_ip="",
+            comments="",
+            tags=["evidence"],
+        )
+        OplogEntryFactory(
+            oplog_id=self.oplog,
+            start_date=datetime(2024, 5, 2, 9, 0, 0, tzinfo=timezone.utc),
+            tags=["internal"],
+        )
+
+        report_evidence = EvidenceOnReportFactory(
+            report=self.report,
+            friendly_name="Alpha",
+        )
+        finding = ReportFindingLinkFactory(report=self.report)
+        finding_evidence = EvidenceOnFindingFactory(
+            finding=finding,
+            friendly_name="Bravo",
+        )
+        foreign_evidence = EvidenceOnReportFactory(
+            report=self.other_report,
+            friendly_name="Foreign",
+        )
+
+        OplogEntryEvidenceFactory(oplog_entry=entry_one, evidence=report_evidence)
+        OplogEntryEvidenceFactory(oplog_entry=entry_one, evidence=finding_evidence)
+        OplogEntryEvidenceFactory(oplog_entry=entry_one, evidence=foreign_evidence)
+
+        response = self.client_mgr.post(
+            self.uri,
+            data=json.dumps({"oplog_id": self.oplog.pk}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(
+            body["blocks"],
+            [
+                {
+                    "type": "paragraph",
+                    "text": (
+                        f"On {dateformat(first_start, settings.DATE_FORMAT)} at 14:00:00 UTC, "
+                        "the assessment team used Nmap from 10.0.0.10 against 10.0.0.20. "
+                        "Comments: Initial foothold confirmed."
+                    ),
+                },
+                {"type": "paragraph", "text": "{{.ref Alpha}}"},
+                {"type": "evidence", "evidence_id": report_evidence.id},
+                {"type": "paragraph", "text": "{{.ref Bravo}}"},
+                {"type": "evidence", "evidence_id": finding_evidence.id},
+                {
+                    "type": "paragraph",
+                    "text": (
+                        "At 15:30:00 UTC, the assessment team used N/A from N/A "
+                        "against N/A. Comments: N/A"
+                    ),
+                },
+            ],
+        )
 
 
 class ReportCreateViewTests(TestCase):

--- a/ghostwriter/reporting/urls.py
+++ b/ghostwriter/reporting/urls.py
@@ -167,6 +167,11 @@ urlpatterns += [
         name="report_extra_field_edit",
     ),
     path(
+        "reports/<int:pk>/generate-oplog-outline",
+        ghostwriter.reporting.views2.report.ReportOplogOutlineGenerate.as_view(),
+        name="report_generate_oplog_outline",
+    ),
+    path(
         "templates/<int:pk>",
         ghostwriter.reporting.views2.report.ReportTemplateDetailView.as_view(),
         name="template_detail",

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -549,8 +549,13 @@ class ReportOplogOutlineGenerate(RoleBasedAccessControlMixin, SingleObjectMixin,
         return self.get_object().user_can_edit(self.request.user)
 
     def handle_no_permission(self):
-        messages.error(self.request, "You do not have permission to access that.")
-        return redirect("home:dashboard")
+        return JsonResponse(
+            {
+                "result": "error",
+                "message": "You do not have permission to access that.",
+            },
+            status=403,
+        )
 
     def post(self, request, *args, **kwargs):
         report = self.get_object()

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -1,6 +1,7 @@
 
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 import io
+import json
 import os
 import logging
 import mimetypes
@@ -14,6 +15,7 @@ from django.http import (
     Http404,
     HttpResponse,
     HttpResponseRedirect,
+    JsonResponse,
 )
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -23,6 +25,8 @@ from django.views.generic.list import ListView
 from django.views.generic import View
 from django.conf import settings
 from django.contrib import messages
+from django.utils import dateformat, timezone
+from django.utils.html import strip_tags
 from channels.layers import get_channel_layer
 from taggit.models import Tag
 
@@ -37,6 +41,7 @@ from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.modules.reportwriter.report.pptx import ExportReportPptx
 from ghostwriter.modules.reportwriter.report.xlsx import ExportReportXlsx
 from ghostwriter.modules.shared import add_content_disposition_header
+from ghostwriter.oplog.models import Oplog, OplogEntry
 from ghostwriter.reporting.archive import archive_report
 from ghostwriter.reporting.filters import ReportFilter, ReportTemplateFilter
 from ghostwriter.reporting.forms import ReportForm, ReportTemplateForm, SelectReportTemplateForm
@@ -45,6 +50,101 @@ from ghostwriter.rolodex.models import Project
 
 logger = logging.getLogger(__name__)
 channel_layer = get_channel_layer()
+
+
+def _outline_value(value):
+    """Return plain text content for outline sentences, defaulting blanks to ``N/A``."""
+    text = strip_tags(value or "").strip()
+    return text if text else "N/A"
+
+
+def _entry_start_utc(entry: OplogEntry) -> datetime:
+    """Normalize an oplog entry timestamp to an aware UTC ``datetime``."""
+    start_date = entry.start_date
+    if timezone.is_naive(start_date):
+        start_date = timezone.make_aware(start_date, dt_timezone.utc)
+    return start_date.astimezone(dt_timezone.utc)
+
+
+def _report_evidence_refs_for_entry(report: Report, entry: OplogEntry) -> list[tuple[str, int]]:
+    """
+    Return the linked evidence references for an entry that belong to the target report.
+
+    The result is ordered by friendly name so the generated outline is deterministic.
+    """
+    evidence_by_name: dict[str, int] = {}
+    for link in entry.evidence_links.all():
+        evidence = link.evidence
+        evidence_report_id = evidence.report_id
+        if evidence_report_id is None and evidence.finding_id is not None:
+            evidence_report_id = evidence.finding.report_id
+        if evidence_report_id != report.id:
+            continue
+        friendly_name = evidence.friendly_name.strip()
+        if not friendly_name:
+            continue
+        evidence_by_name[friendly_name] = evidence.id
+    return [(name, evidence_by_name[name]) for name in sorted(evidence_by_name)]
+
+
+def generate_oplog_outline_blocks(report: Report, oplog: Oplog) -> list[dict[str, int | str]]:
+    """
+    Build Tiptap-ready outline content for a report extra field from an oplog.
+
+    The returned blocks are either paragraph text or evidence node references so the
+    frontend can append real evidence embeds with previews instead of legacy keyword text.
+    """
+    entries = (
+        OplogEntry.objects.filter(
+            oplog_id=oplog,
+            start_date__isnull=False,
+            tags__name__in=["report", "evidence"],
+        )
+        .prefetch_related(
+            "evidence_links__evidence__report",
+            "evidence_links__evidence__finding__report",
+        )
+        .order_by("start_date", "pk")
+        .distinct()
+    )
+
+    blocks: list[dict[str, int | str]] = []
+    previous_day = None
+    for entry in entries:
+        dt = _entry_start_utc(entry)
+        current_day = dt.date()
+        if current_day != previous_day:
+            timestamp = (
+                f"On {dateformat.format(dt, settings.DATE_FORMAT)} "
+                f"at {dt.strftime('%H:%M:%S')} UTC"
+            )
+            previous_day = current_day
+        else:
+            timestamp = f"At {dt.strftime('%H:%M:%S')} UTC"
+
+        blocks.append(
+            (
+                {
+                    "type": "paragraph",
+                    "text": (
+                        "{timestamp}, the assessment team used {tool} from {source} "
+                        "against {dest}. Comments: {comments}"
+                    ).format(
+                        timestamp=timestamp,
+                        tool=_outline_value(entry.tool),
+                        source=_outline_value(entry.source_ip),
+                        dest=_outline_value(entry.dest_ip),
+                        comments=_outline_value(entry.comments),
+                    ),
+                }
+            )
+        )
+
+        for friendly_name, evidence_id in _report_evidence_refs_for_entry(report, entry):
+            blocks.append({"type": "paragraph", "text": "{{.ref " + friendly_name + "}}"})
+            blocks.append({"type": "evidence", "evidence_id": evidence_id})
+
+    return blocks
 
 class ReportListView(RoleBasedAccessControlMixin, ListView):
     """
@@ -429,7 +529,56 @@ class ReportExtraFieldEdit(CollabModelUpdate):
         ctx = super().get_context_data(**kwargs)
         field = get_object_or_404(ExtraFieldSpec.for_model(self.model), internal_name=self.extra_field_name)
         ctx["target_field"] = field
+        ctx["report_oplogs"] = list(
+            self.object.project.oplog_set.order_by("name", "pk").values("id", "name")
+        )
         return ctx
+
+
+class ReportOplogOutlineGenerate(RoleBasedAccessControlMixin, SingleObjectMixin, View):
+    """
+    Generate Tiptap content blocks for an oplog narrative outline.
+
+    The frontend uses these blocks to append normal paragraphs and first-class evidence
+    embeds into a report extra field.
+    """
+
+    model = Report
+
+    def test_func(self):
+        return self.get_object().user_can_edit(self.request.user)
+
+    def handle_no_permission(self):
+        messages.error(self.request, "You do not have permission to access that.")
+        return redirect("home:dashboard")
+
+    def post(self, request, *args, **kwargs):
+        report = self.get_object()
+
+        try:
+            payload = json.loads(request.body.decode("utf-8"))
+        except (TypeError, json.JSONDecodeError):
+            return JsonResponse(
+                {"result": "error", "message": "Could not read the selected oplog."},
+                status=400,
+            )
+
+        oplog_id = payload.get("oplog_id")
+        if not isinstance(oplog_id, int):
+            return JsonResponse(
+                {"result": "error", "message": "Select an oplog before generating the outline."},
+                status=400,
+            )
+
+        oplog = get_object_or_404(Oplog, pk=oplog_id, project=report.project)
+        blocks = generate_oplog_outline_blocks(report, oplog)
+        return JsonResponse(
+            {
+                "result": "success",
+                "blocks": blocks,
+                "message": "Generated outline successfully.",
+            }
+        )
 
 
 class ReportTemplateListView(RoleBasedAccessControlMixin, ListView):

--- a/ghostwriter/templates/base_generic.html
+++ b/ghostwriter/templates/base_generic.html
@@ -130,7 +130,7 @@
                                                 " activate-report-csrftoken="{{ csrf_token }}"
                        activate-report-url="{% url 'reporting:ajax_activate_report' report.id %}"
                        activate-report-id="{{ report.id }}">
-                      {{ report.title }}</a>
+                      {{ report.title }} ({{ report.project.codename }})</a>
                   </li>
                 {% endfor %}
               {% else %}

--- a/javascript/src/frontend/collab_forms/forms/report_field.tsx
+++ b/javascript/src/frontend/collab_forms/forms/report_field.tsx
@@ -4,12 +4,16 @@ import { createRoot } from "react-dom/client";
 import { ExtraFieldInput, useExtraFieldSpecs } from "../extra_fields";
 import { Editor } from "@tiptap/core";
 import EvidenceButton from "../rich_text_editor/evidence";
+import OplogOutlineButton from "../rich_text_editor/oplog_outline";
 import PageGraphqlProvider from "../../graphql/client";
 import { ProvidePageEvidence } from "../../graphql/evidence";
 import ErrorBoundary from "../error_boundary";
 
 const renderToolbarExtra = (editor: Editor) => (
-    <EvidenceButton editor={editor} />
+    <>
+        <EvidenceButton editor={editor} />
+        <OplogOutlineButton editor={editor} />
+    </>
 );
 
 function ReportExtraFieldForm(props: { field: string }) {

--- a/javascript/src/frontend/collab_forms/rich_text_editor/oplog_outline.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/oplog_outline.tsx
@@ -1,0 +1,250 @@
+import { useId, useMemo, useState } from "react";
+import ReactModal from "react-modal";
+import { Editor } from "@tiptap/core";
+import { getCsrfToken } from "../../../services/csrf";
+
+type OplogChoice = {
+    id: number;
+    name: string;
+};
+
+type OutlineBlock =
+    | { type: "paragraph"; text: string }
+    | { type: "evidence"; evidence_id: number };
+
+type ToastLevel = "success" | "warning" | "error" | "info";
+
+declare global {
+    interface Window {
+        displayToastTop?: (args: {
+            type: ToastLevel;
+            string: string;
+            title?: string;
+            delay?: number;
+        }) => void;
+    }
+}
+
+function showToast(type: ToastLevel, string: string, title = "Oplog Outline") {
+    window.displayToastTop?.({ type, string, title });
+}
+
+function getOplogChoices(): OplogChoice[] {
+    const el = document.getElementById("report-oplog-options");
+    if (!el?.textContent) {
+        return [];
+    }
+    return JSON.parse(el.textContent) as OplogChoice[];
+}
+
+function getGenerateUrl(): string {
+    return document.getElementById("report-oplog-outline-url")?.textContent ?? "";
+}
+
+export default function OplogOutlineButton({ editor }: { editor: Editor }) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <>
+            <button
+                type="button"
+                tabIndex={-1}
+                title="Append oplog outline"
+                onClick={(ev) => {
+                    ev.preventDefault();
+                    setIsOpen(true);
+                }}
+            >
+                Insert Log Narrative
+            </button>
+            {isOpen && (
+                <OplogOutlineModal
+                    editor={editor}
+                    onClose={() => setIsOpen(false)}
+                />
+            )}
+        </>
+    );
+}
+
+function OplogOutlineModal(props: { editor: Editor; onClose: () => void }) {
+    const oplogs = useMemo(() => getOplogChoices(), []);
+    const [selectedId, setSelectedId] = useState<number | null>(
+        oplogs.length === 1 ? oplogs[0].id : null
+    );
+    const [state, setState] = useState<"idle" | "loading">("idle");
+    const selectId = useId();
+
+    const disabled = state === "loading";
+    const canSubmit = selectedId !== null && !disabled;
+
+    return (
+        <ReactModal
+            isOpen
+            onRequestClose={props.onClose}
+            contentLabel="Append Oplog Outline"
+            className="modal-dialog modal-dialog-centered"
+        >
+            <div className="modal-content">
+                <div className="modal-header">
+                    <h5 className="modal-title">Append Oplog Outline</h5>
+                </div>
+                <div className="modal-body">
+                    <p>
+                        Appends a narrative outline based on operation log entries tagged with
+                        <code> report </code>
+                        or
+                        <code> evidence </code>
+                        to the end of this field. Any linked evidence will be included as well.
+                    </p>
+                    <p className="mb-3">
+                        This is useful for quickly assembling a report
+                        outline based on relevant activity recorded in the log(s).
+                        You can edit the generated outline as needed after it has been inserted.
+                    </p>
+                    <div className="form-group">
+                        <label htmlFor={selectId}>Operation Logs</label>
+                        <select
+                            id={selectId}
+                            className="custom-select custom-select-lg"
+                            disabled={disabled || oplogs.length === 0}
+                            value={selectedId?.toString() ?? ""}
+                            onChange={(ev) => {
+                                setSelectedId(
+                                    ev.target.value === ""
+                                        ? null
+                                        : parseInt(ev.target.value, 10)
+                                );
+                            }}
+                        >
+                            <option value="">Select Log...</option>
+                            {oplogs.map((oplog) => (
+                                <option key={oplog.id} value={oplog.id}>
+                                    {oplog.name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    {oplogs.length === 0 && (
+                        <div className="alert alert-warning mb-0" role="alert">
+                            No oplogs are available for this report&apos;s
+                            project.
+                        </div>
+                    )}
+                </div>
+                <div className="modal-footer">
+                    <button
+                        className="btn btn-primary"
+                        disabled={!canSubmit}
+                        onClick={(ev) => {
+                            ev.preventDefault();
+                            void appendOutline(
+                                props.editor,
+                                selectedId,
+                                setState,
+                                props.onClose
+                            );
+                        }}
+                    >
+                        Append Outline
+                    </button>
+                    <button
+                        className="btn btn-outline-secondary"
+                        disabled={disabled}
+                        onClick={(ev) => {
+                            ev.preventDefault();
+                            props.onClose();
+                        }}
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </ReactModal>
+    );
+}
+
+async function appendOutline(
+    editor: Editor,
+    oplogId: number | null,
+    setState: (state: "idle" | "loading") => void,
+    close: () => void
+) {
+    if (oplogId === null) {
+        showToast("warning", "Select an oplog before generating the outline.");
+        return;
+    }
+
+    const csrfToken = getCsrfToken();
+    if (!csrfToken) {
+        showToast("error", "CSRF token not found. Please refresh the page.");
+        return;
+    }
+
+    const url = getGenerateUrl();
+    if (!url) {
+        showToast("error", "Outline generation URL is missing.");
+        return;
+    }
+
+    setState("loading");
+    try {
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json",
+                "X-CSRFToken": csrfToken,
+            },
+            body: JSON.stringify({ oplog_id: oplogId }),
+        });
+        const payload = (await response.json()) as {
+            blocks?: OutlineBlock[];
+            message?: string;
+        };
+
+        if (!response.ok) {
+            showToast(
+                "error",
+                payload.message || "Could not generate the oplog outline."
+            );
+            return;
+        }
+
+        const blocks = payload.blocks ?? [];
+        if (blocks.length === 0) {
+            showToast(
+                "info",
+                "No reportable oplog entries were found for this log."
+            );
+            close();
+            return;
+        }
+
+        editor
+            .chain()
+            .focus("end")
+            .insertContent(
+                blocks.map((block) =>
+                    block.type === "paragraph"
+                        ? {
+                              type: "paragraph",
+                              content: block.text
+                                  ? [{ type: "text", text: block.text }]
+                                  : [],
+                          }
+                        : {
+                              type: "evidence",
+                              attrs: { id: block.evidence_id },
+                          }
+                )
+            )
+            .run();
+        close();
+    } catch (error) {
+        console.error(error);
+        showToast("error", "Could not generate the oplog outline.");
+    } finally {
+        setState("idle");
+    }
+}


### PR DESCRIPTION
# CHANGELOG

## [6.3.0] - 10 April 2026

### Added

* **Build a Narrative Outline from Log Entries**: Construct an outline for a report narrative based on tagged log entries
  * This is useful for quickly generating a narrative outline to kickstart a report draft
  * Added a button to the collaborative editor to insert a narrative outline based on activity logs
  * The action includes any log entries tagged with `evidence` or `report`
  * Each line includes the start date and time, tool used, target, and comments
  * The action also inserts evidence objects below each line for any evidence linked with that entry
* Report names in the sidebar now also include the parent project's codename to aid in identification