### PR TITLE
Code clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The collaborative editor's color picker now validates color values
 * Added sanitization to strip some characters from the export filenames for operation logs for safer exports
 * The start script for Django will now run the `migrate_totp_device` to migrate MFA records set up prior to v6.1
+* Restricted links in the collaborative editor to valid URL schemes (e.g., http, https, mailto)
+* Changed the `to_datetime` filter to not require a format string
+  * The filter will now automatically match a format string with Django's `DATE_INPUT_FORMATS` when a format string is not provided
+* Adjusted tag autocomplete to only offer tags already applied to objects to which the user has access
 
 ### Fixed
 
@@ -39,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed sanitizing the identifier on log entries
 * Fixed an issue that could occur with `filter_bhe_findings_by_domain` when domain SID or BloodHound `environment_id` were empty
 * Fixed an edge case where a single contact on a client or project could be flagged as not the primary contact
+* Fixed an issue that prevented report archives from being created
+* Fixed the table caption "Set Bookmark" command in the editor being available when it should not be
+
+### Security
+
+* Restored the HttpOnly flag to cookies
+* Restricted collab-server inspector to localhost for development environments
 
 ## [6.3.0] - 10 April 2026
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -271,7 +271,7 @@ SESSION_SAVE_EVERY_REQUEST = env("DJANGO_SESSION_SAVE_EVERY_REQUEST", default=Tr
 # https://docs.djangoproject.com/en/3.2/ref/settings/#session-cookie-secure
 SESSION_COOKIE_SECURE = env("DJANGO_SESSION_COOKIE_SECURE", default=False)
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-httponly
-CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_HTTPONLY = True
 # https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-cookie-secure
 CSRF_COOKIE_SECURE = env("DJANGO_CSRF_COOKIE_SECURE", default=False)
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-browser-xss-filter

--- a/ghostwriter/commandcenter/templates/collab_editing/attrs_snippet.html
+++ b/ghostwriter/commandcenter/templates/collab_editing/attrs_snippet.html
@@ -1,5 +1,6 @@
 {% load static %}
 
+<meta name="csrf-token" content="{{ csrf_token }}">
 <script type="text/plain" id="yjs-url">/ws-collab</script>
 <script type="text/plain" id="yjs-object-id">{{collab_model_id}}</script>
 <script type="text/plain" id="yjs-username">{{collab_user.get_username}}</script>

--- a/ghostwriter/modules/reportwriter/jinja_funcs.py
+++ b/ghostwriter/modules/reportwriter/jinja_funcs.py
@@ -11,6 +11,9 @@ from bs4 import BeautifulSoup
 from dateutil.parser import parse as parse_datetime
 from dateutil.parser._parser import ParserError
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django import forms
+from django.utils import formats
 from django.utils.dateformat import format as dateformat
 import jinja2
 from markupsafe import Markup
@@ -199,15 +202,20 @@ def to_datetime(date, format_str=None):
     ``date``
         Date string to convert
     ``format_str``
-        Format string to use for conversion (uses the global setting if omitted)
+        Format string to use for conversion (uses Django's configured date input formats if omitted)
     """
     try:
         if isinstance(date, datetime):
             return date
         if format_str:
             return datetime.strptime(date, format_str)
-        return parse_datetime(date)
-    except (ParserError, TypeError, ValueError) as e:
+        return datetime.combine(
+            forms.DateField(
+                input_formats=formats.get_format("DATE_INPUT_FORMATS")
+            ).clean(date),
+            datetime.min.time(),
+        )
+    except (ParserError, TypeError, ValueError, ValidationError) as e:
         logger.exception("Error parsing ``date`` with the provided format: %s", date)
         raise InvalidFilterValue(f'Invalid date and format string ("{date}", "{format_str}") passed into the `to_datetime()` filter') from e
 

--- a/ghostwriter/modules/reportwriter/jinja_funcs.py
+++ b/ghostwriter/modules/reportwriter/jinja_funcs.py
@@ -190,7 +190,7 @@ def format_datetime(date, new_format=None):
     return formatted_date
 
 
-def to_datetime(date, format_str):
+def to_datetime(date, format_str=None):
     """
     Convert a date string to a datetime object using the given format.
 
@@ -199,11 +199,15 @@ def to_datetime(date, format_str):
     ``date``
         Date string to convert
     ``format_str``
-        Format string to use for conversion
+        Format string to use for conversion (uses the global setting if omitted)
     """
     try:
-        return datetime.strptime(date, format_str)
-    except ValueError as e:
+        if isinstance(date, datetime):
+            return date
+        if format_str:
+            return datetime.strptime(date, format_str)
+        return parse_datetime(date)
+    except (ParserError, TypeError, ValueError) as e:
         logger.exception("Error parsing ``date`` with the provided format: %s", date)
         raise InvalidFilterValue(f'Invalid date and format string ("{date}", "{format_str}") passed into the `to_datetime()` filter') from e
 

--- a/ghostwriter/modules/reportwriter/richtext/ooxml.py
+++ b/ghostwriter/modules/reportwriter/richtext/ooxml.py
@@ -8,6 +8,8 @@ import bs4
 
 logger = logging.getLogger(__name__)
 
+ALLOWED_HYPERLINK_PROTOCOLS = {"http", "https", "mailto", "tel"}
+
 
 def set_style_method(tag_name, style_key, style_value=True):
     """
@@ -168,7 +170,10 @@ class BaseHtmlToOOXML:
     tag_del = set_style_method("del", "strikethrough")
 
     def tag_a(self, el, *, style={}, **kwargs):
-        style = style | {"hyperlink_url": el.attrs.get("href")}
+        style = style.copy()
+        hyperlink_url = sanitize_hyperlink_url(el.attrs.get("href"))
+        if hyperlink_url:
+            style["hyperlink_url"] = hyperlink_url
         self.process_children(el.children, style=style, **kwargs)
 
     def tag_span(self, el, *, style={}, **kwargs):
@@ -310,6 +315,32 @@ def strip_text_whitespace(text: str):
     Consolidates adjacent whitespace into one space, similar to how browsers display it
     """
     return re.sub(r"\s+", " ", text)
+
+
+def sanitize_hyperlink_url(url: str | None) -> str | None:
+    """
+    Allow safe relative URLs and a small allowlist of schemes for exported hyperlinks.
+    """
+    if not url:
+        return None
+    trimmed_url = url.strip()
+    if not trimmed_url or re.search(r"[\x00-\x20\x7f]", trimmed_url):
+        return None
+    if trimmed_url.startswith(("#", "?")):
+        return trimmed_url
+    if (
+        (trimmed_url.startswith("/") and not trimmed_url.startswith("//"))
+        or trimmed_url.startswith("./")
+        or trimmed_url.startswith("../")
+    ):
+        return trimmed_url
+
+    match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", trimmed_url)
+    if match:
+        return trimmed_url if match.group(1).lower() in ALLOWED_HYPERLINK_PROTOCOLS else None
+    if trimmed_url.startswith("//"):
+        return None
+    return trimmed_url
 
 
 def parse_styles(style: str, handle):

--- a/ghostwriter/modules/shared.py
+++ b/ghostwriter/modules/shared.py
@@ -69,3 +69,8 @@ def search_tags(queryset, value):
     """Filter a queryset by tags."""
     # There is no case-insensitive version of `in` for Django ORM, so we use `iregex` instead.
     return queryset.filter(tags__name__iregex=r"(" + value + ")").distinct()
+
+
+def get_tags_for_queryset(queryset):
+    """Return the distinct tags attached to objects in the provided queryset."""
+    return Tag.objects.filter(id__in=queryset.values_list("tags__id", flat=True)).order_by("name").distinct()

--- a/ghostwriter/reporting/models.py
+++ b/ghostwriter/reporting/models.py
@@ -473,8 +473,7 @@ class ReportTemplate(models.Model):
 
             return ExportReportDocx(
                 object,
-                template_loc=self.document.path,
-                p_style=self.p_style,
+                report_template=self,
                 **kwargs
             )
         if self.doc_type.doc_type == "project_docx":

--- a/ghostwriter/reporting/tests/test_models.py
+++ b/ghostwriter/reporting/tests/test_models.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 # Ghostwriter Libraries
+from ghostwriter.modules.reportwriter.report.docx import ExportReportDocx
 from ghostwriter.commandcenter.models import ReportConfiguration
 from ghostwriter.factories import (
     ArchiveFactory,
@@ -291,6 +292,14 @@ class ReportTemplateModelTests(TestCase):
             self.assertEqual("success", status)
         except Exception:
             self.fail("ReportTemplate model `get_status` method failed unexpectedly with PPTX template!")
+
+    def test_exporter_uses_report_template_for_docx_exports(self):
+        report = ReportFactory()
+
+        exporter = report.docx_template.exporter(report)
+
+        self.assertIsInstance(exporter, ExportReportDocx)
+        self.assertEqual(exporter.report_template, report.docx_template)
 
     def test_update_upload_date_signal(self):
         # Create a template with an initial document

--- a/ghostwriter/reporting/tests/test_rich_text_docx.py
+++ b/ghostwriter/reporting/tests/test_rich_text_docx.py
@@ -78,6 +78,38 @@ def mk_test_docx(name, input, expected_output, p_style=None):
 class RichTextToDocxTests(SimpleTestCase):
     maxDiff = None
 
+    def test_safe_links_are_preserved(self):
+        doc = docx.Document()
+        HtmlToDocx.run('<p><a href="https://example.com">Example</a></p>', doc, None)
+        out = BytesIO()
+        doc.part.save(out)
+
+        with ZipFile(out) as zip:
+            with zip.open("word/document.xml") as file:
+                document_xml = file.read().decode("utf-8")
+            with zip.open("word/_rels/document.xml.rels") as file:
+                rels_xml = file.read().decode("utf-8")
+
+        self.assertIn("Example", document_xml)
+        self.assertIn("w:hyperlink", document_xml)
+        self.assertIn('Target="https://example.com"', rels_xml)
+
+    def test_unsafe_links_are_removed(self):
+        doc = docx.Document()
+        HtmlToDocx.run('<p><a href="javascript:alert(1)">Example</a></p>', doc, None)
+        out = BytesIO()
+        doc.part.save(out)
+
+        with ZipFile(out) as zip:
+            with zip.open("word/document.xml") as file:
+                document_xml = file.read().decode("utf-8")
+            with zip.open("word/_rels/document.xml.rels") as file:
+                rels_xml = file.read().decode("utf-8")
+
+        self.assertIn("Example", document_xml)
+        self.assertNotIn("w:hyperlink", document_xml)
+        self.assertNotIn("javascript:alert(1)", rels_xml)
+
     test_paragraphs = mk_test_docx(
         "test_paragraphs",
         "<p>Hello World!</p><p>This is a test!</p>",

--- a/ghostwriter/reporting/tests/test_rich_text_pptx.py
+++ b/ghostwriter/reporting/tests/test_rich_text_pptx.py
@@ -95,6 +95,46 @@ def mk_test_pptx(name, input, expected_output, add_suffix=True):
 class RichTextToPptxTests(SimpleTestCase):
     maxDiff = None
 
+    def test_safe_links_are_preserved(self):
+        ppt = pptx.Presentation()
+        slide = ppt.slides.add_slide(ppt.slide_layouts[SLD_LAYOUT_TITLE_AND_CONTENT])
+        shape = slide.shapes.placeholders[1]
+        shape.text_frame.clear()
+        HtmlToPptx.run('<p><a href="mailto:test@example.com">Email</a></p>', slide, shape)
+        HtmlToPptx.delete_extra_paragraph(shape)
+
+        out = BytesIO()
+        ppt.part.save(out)
+
+        with ZipFile(out) as zip:
+            with zip.open("ppt/slides/slide1.xml") as file:
+                slide_xml = file.read().decode("utf-8")
+            with zip.open("ppt/slides/_rels/slide1.xml.rels") as file:
+                rels_xml = file.read().decode("utf-8")
+
+        self.assertIn("Email", slide_xml)
+        self.assertIn("mailto:test@example.com", rels_xml)
+
+    def test_unsafe_links_are_removed(self):
+        ppt = pptx.Presentation()
+        slide = ppt.slides.add_slide(ppt.slide_layouts[SLD_LAYOUT_TITLE_AND_CONTENT])
+        shape = slide.shapes.placeholders[1]
+        shape.text_frame.clear()
+        HtmlToPptx.run('<p><a href="data:text/html,boom">Email</a></p>', slide, shape)
+        HtmlToPptx.delete_extra_paragraph(shape)
+
+        out = BytesIO()
+        ppt.part.save(out)
+
+        with ZipFile(out) as zip:
+            with zip.open("ppt/slides/slide1.xml") as file:
+                slide_xml = file.read().decode("utf-8")
+            with zip.open("ppt/slides/_rels/slide1.xml.rels") as file:
+                rels_xml = file.read().decode("utf-8")
+
+        self.assertIn("Email", slide_xml)
+        self.assertNotIn("data:text/html,boom", rels_xml)
+
     test_paragraphs = mk_test_pptx(
         "test_paragraphs",
         "<p>Hello World!</p><p>This is a test!</p>",

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from django.contrib.messages import get_messages
 from django.conf import settings
 from django.test import Client, TestCase
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.dateformat import format as dateformat
 from django.utils.encoding import force_str
@@ -3100,6 +3101,20 @@ class ReportTemplateFilterTests(TestCase):
         test_date = dateformat(self.test_date, self.test_date_string)
 
         parsed_date = to_datetime(test_date, None)
+        self.assertEqual(parsed_date, self.test_date)
+
+    @override_settings(DATE_INPUT_FORMATS=["%m/%d/%Y"])
+    def test_to_datetime_uses_overridden_default_numeric_input_format(self):
+        test_date = dateformat(self.test_date, "m/d/Y")
+
+        parsed_date = to_datetime(test_date)
+        self.assertEqual(parsed_date, self.test_date)
+
+    @override_settings(DATE_INPUT_FORMATS=["%d %B %Y"])
+    def test_to_datetime_uses_overridden_default_month_name_input_format(self):
+        test_date = dateformat(self.test_date, "d F Y")
+
+        parsed_date = to_datetime(test_date)
         self.assertEqual(parsed_date, self.test_date)
 
     def test_to_datetime_with_invalid_string(self):

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -1142,6 +1142,20 @@ class ReportsListViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.context["filter"].qs) == 5)
 
+    def test_tags_are_scoped_to_visible_reports(self):
+        visible_report = ReportFactory(title="Visible Report")
+        hidden_report = ReportFactory(title="Hidden Report")
+        ProjectAssignmentFactory(project=visible_report.project, operator=self.user)
+        visible_report.tags.add("visible-report-tag")
+        hidden_report.tags.add("hidden-report-tag")
+
+        response = self.client_auth.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+
+        tag_names = list(response.context["tags"].values_list("name", flat=True))
+        self.assertIn("visible-report-tag", tag_names)
+        self.assertNotIn("hidden-report-tag", tag_names)
+
 
 class ReportDetailViewTests(TestCase):
     """Collection of tests for :view:`reporting.ReportDetailView`."""

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -3070,6 +3070,24 @@ class ReportTemplateFilterTests(TestCase):
         parsed_date = to_datetime(test_date, "%d %b %Y")
         self.assertEqual(parsed_date, self.test_date)
 
+    def test_to_datetime_uses_default_format_when_omitted(self):
+        test_date = dateformat(self.test_date, self.test_date_string)
+
+        parsed_date = to_datetime(test_date)
+        self.assertEqual(parsed_date, self.test_date)
+
+    def test_to_datetime_uses_default_format_when_empty(self):
+        test_date = dateformat(self.test_date, self.test_date_string)
+
+        parsed_date = to_datetime(test_date, "")
+        self.assertEqual(parsed_date, self.test_date)
+
+    def test_to_datetime_uses_default_format_when_none(self):
+        test_date = dateformat(self.test_date, self.test_date_string)
+
+        parsed_date = to_datetime(test_date, None)
+        self.assertEqual(parsed_date, self.test_date)
+
     def test_to_datetime_with_invalid_string(self):
         test_date = "Not a Date"
         with self.assertRaises(InvalidFilterValue):

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -28,8 +28,6 @@ from django.contrib import messages
 from django.utils import dateformat, timezone
 from django.utils.html import strip_tags
 from channels.layers import get_channel_layer
-from taggit.models import Tag
-
 from ghostwriter.api.utils import RoleBasedAccessControlMixin, get_reports_list, get_templates_list, verify_user_is_privileged
 from ghostwriter.commandcenter.models import BloodHoundConfiguration, ExtraFieldSpec, ReportConfiguration
 from ghostwriter.commandcenter.views import CollabModelUpdate
@@ -41,6 +39,7 @@ from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.modules.reportwriter.report.pptx import ExportReportPptx
 from ghostwriter.modules.reportwriter.report.xlsx import ExportReportXlsx
 from ghostwriter.modules.shared import add_content_disposition_header
+from ghostwriter.modules.shared import get_tags_for_queryset
 from ghostwriter.oplog.models import Oplog, OplogEntry
 from ghostwriter.reporting.archive import archive_report
 from ghostwriter.reporting.filters import ReportFilter, ReportTemplateFilter
@@ -181,11 +180,12 @@ class ReportListView(RoleBasedAccessControlMixin, ListView):
         return get_reports_list(self.request.user)
 
     def get(self, request, *args, **kwarg):
-        reports_filter = ReportFilter(request.GET, queryset=self.get_queryset())
+        queryset = self.get_queryset()
+        reports_filter = ReportFilter(request.GET, queryset=queryset)
         return render(
             request,
             "reporting/report_list.html",
-            {"filter": reports_filter, "tags": Tag.objects.all()}
+            {"filter": reports_filter, "tags": get_tags_for_queryset(queryset)}
         )
 
 

--- a/ghostwriter/rolodex/tests/test_views.py
+++ b/ghostwriter/rolodex/tests/test_views.py
@@ -700,6 +700,20 @@ class ClientListViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["filter"].qs), 2)
 
+    def test_tags_are_scoped_to_visible_clients(self):
+        visible_client = ClientFactory(name="Visible Client")
+        hidden_client = ClientFactory(name="Hidden Client")
+        ClientInviteFactory(user=self.user, client=visible_client)
+        visible_client.tags.add("visible-tag")
+        hidden_client.tags.add("hidden-tag")
+
+        response = self.client_auth.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+
+        tag_names = list(response.context["tags"].values_list("name", flat=True))
+        self.assertIn("visible-tag", tag_names)
+        self.assertNotIn("hidden-tag", tag_names)
+
 
 class ClientDetailViewTest(TestCase):
     @classmethod
@@ -807,6 +821,20 @@ class ProjectListViewTests(TestCase):
         response = self.client_mgr.get(f"{self.uri}?client=SpecterOps")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["filter"].qs), 1)
+
+    def test_tags_are_scoped_to_visible_projects(self):
+        visible_project = ProjectFactory(codename="VISIBLE")
+        hidden_project = ProjectFactory(codename="HIDDEN")
+        ProjectInviteFactory(user=self.user, project=visible_project)
+        visible_project.tags.add("visible-project-tag")
+        hidden_project.tags.add("hidden-project-tag")
+
+        response = self.client_auth.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+
+        tag_names = list(response.context["tags"].values_list("name", flat=True))
+        self.assertIn("visible-project-tag", tag_names)
+        self.assertNotIn("hidden-project-tag", tag_names)
 
         response = self.client_mgr.get(f"{self.uri}?client=pops")
         self.assertEqual(response.status_code, 200)
@@ -1154,4 +1182,3 @@ class ClientLogoDownloadTests(TestCase):
         self.assertEqual(response.get("X-Content-Type-Options"), "nosniff")
         # CSP is only added for inline responses
         self.assertIsNone(response.get("Content-Security-Policy"))
-

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -34,7 +34,6 @@ from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.db.models import Exists, OuterRef
 
 # 3rd Party Libraries
-from taggit.models import Tag
 
 # Ghostwriter Libraries
 from ghostwriter.api.utils import (
@@ -51,6 +50,7 @@ from ghostwriter.modules.model_utils import to_dict
 from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 from ghostwriter.modules.reportwriter.project.json import ExportProjectJson
 from ghostwriter.modules.shared import add_content_disposition_header
+from ghostwriter.modules.shared import get_tags_for_queryset
 from ghostwriter.reporting.models import ReportTemplate
 from ghostwriter.rolodex.filters import ClientFilter, ProjectFilter
 from ghostwriter.rolodex.forms_client import (
@@ -1235,9 +1235,10 @@ class ClientListView(RoleBasedAccessControlMixin, ListView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["filter"] = ClientFilter(self.request.GET, queryset=self.get_queryset(), request=self.request)
+        queryset = self.get_queryset()
+        ctx["filter"] = ClientFilter(self.request.GET, queryset=queryset, request=self.request)
         ctx["autocomplete"] = self.autocomplete
-        ctx["tags"] = Tag.objects.all()
+        ctx["tags"] = get_tags_for_queryset(queryset)
         return ctx
 
 
@@ -1666,14 +1667,15 @@ class ProjectListView(RoleBasedAccessControlMixin, ListView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
+        queryset = self.get_queryset()
         # Copy the GET request data
         data = self.request.GET.copy()
         # If user has not submitted their own filter, default to showing only active projects
         if len(data) == 0:
             data["complete"] = 0
-        ctx["filter"] = ProjectFilter(data, queryset=self.get_queryset(), request=self.request)
+        ctx["filter"] = ProjectFilter(data, queryset=queryset, request=self.request)
         ctx["autocomplete"] = self.autocomplete
-        ctx["tags"] = Tag.objects.all()
+        ctx["tags"] = get_tags_for_queryset(queryset)
         return ctx
 
 

--- a/javascript/src/collab_server/yjs_converters.ts
+++ b/javascript/src/collab_server/yjs_converters.ts
@@ -8,6 +8,30 @@ import { DOMParser, DOMSerializer } from "@tiptap/pm/model";
 import { Window } from "happy-dom";
 
 import { SCHEMA } from "./tiptap_extensions";
+import { sanitizeLinkHref } from "../tiptap_gw/link";
+
+type QueryableNode = {
+    querySelectorAll: (selector: string) => Iterable<{
+        getAttribute: (name: string) => string | null;
+        setAttribute: (name: string, value: string) => void;
+        removeAttribute: (name: string) => void;
+    }>;
+};
+
+function sanitizeAnchorHrefs(root: QueryableNode) {
+    for (const anchor of root.querySelectorAll("a[href]")) {
+        const href = anchor.getAttribute("href");
+        if (!href) {
+            continue;
+        }
+        const sanitizedHref = sanitizeLinkHref(href);
+        if (sanitizedHref) {
+            anchor.setAttribute("href", sanitizedHref);
+        } else {
+            anchor.removeAttribute("href");
+        }
+    }
+}
 
 /**
  * Parses rich text HTML and inserts the content to the YJS XmlFragment
@@ -23,6 +47,7 @@ export function htmlToYjs(html: string, frag: Y.XmlFragment) {
         const fullHtml = `<!DOCTYPE html><html><body>${html}</body></html>`;
         const doc = parser.parseFromString(fullHtml, "text/html");
         if (!doc) throw new Error("Could not parse HTML doc");
+        sanitizeAnchorHrefs(doc.body);
         const ttNode = DOMParser.fromSchema(SCHEMA).parse(
             doc.body as unknown as Node
         );
@@ -44,14 +69,16 @@ export function yjsToHtml(frag: Y.XmlFragment): string {
     // but using the constant SCHEMA.
     const window = new Window();
     try {
-        const doc = DOMSerializer.fromSchema(SCHEMA).serializeFragment(
+        const fragment = DOMSerializer.fromSchema(SCHEMA).serializeFragment(
             node.content,
             {
                 document: window.document as unknown as Document,
             }
         );
-        const serializer = new window.XMLSerializer();
-        return serializer.serializeToString(doc as any);
+        const wrapper = window.document.createElement("div");
+        wrapper.appendChild(fragment as any);
+        sanitizeAnchorHrefs(wrapper);
+        return wrapper.innerHTML;
     } finally {
         window.happyDOM.close();
     }

--- a/javascript/src/frontend/collab_forms/rich_text_editor/link.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/link.tsx
@@ -4,10 +4,12 @@ import { Editor } from "@tiptap/core";
 import { useEditorState } from "@tiptap/react";
 import { useId, useState } from "react";
 import ReactModal from "react-modal";
+import { sanitizeLinkHref } from "../../../tiptap_gw/link";
 
 export default function LinkButton({ editor }: { editor: Editor }) {
     const [modalMode, setModalMode] = useState<null | "new" | "edit">(null);
     const [formUrl, setFormUrl] = useState("");
+    const [validationError, setValidationError] = useState<string | null>(null);
     const urlId = useId();
 
     const { enabled, active } = useEditorState({
@@ -42,6 +44,7 @@ export default function LinkButton({ editor }: { editor: Editor }) {
                     } else {
                         setFormUrl("");
                     }
+                    setValidationError(null);
                     setModalMode(active ? "edit" : "new");
                 }}
             >
@@ -62,8 +65,16 @@ export default function LinkButton({ editor }: { editor: Editor }) {
                         onSubmit={(ev) => {
                             ev.preventDefault();
                             if (formUrl) {
-                                editor.chain().setLink({ href: formUrl }).run();
+                                const sanitizedHref = sanitizeLinkHref(formUrl);
+                                if (!sanitizedHref) {
+                                    setValidationError(
+                                        "Use a relative URL, anchor, or an http, https, mailto, or tel link.",
+                                    );
+                                    return;
+                                }
+                                editor.chain().focus().setLink({ href: sanitizedHref }).run();
                             }
+                            setValidationError(null);
                             setModalMode(null);
                         }}
                     >
@@ -75,9 +86,17 @@ export default function LinkButton({ editor }: { editor: Editor }) {
                                 className="form-control"
                                 value={formUrl}
                                 autoFocus
-                                onChange={(e) => setFormUrl(e.target.value)}
+                                onChange={(e) => {
+                                    setFormUrl(e.target.value);
+                                    setValidationError(null);
+                                }}
                             />
                         </div>
+                        {validationError && (
+                            <div className="alert alert-danger py-2" role="alert">
+                                {validationError}
+                            </div>
+                        )}
 
                         <div className="modal-footer">
                             <button className="btn btn-primary">Save</button>
@@ -88,6 +107,7 @@ export default function LinkButton({ editor }: { editor: Editor }) {
                                     onClick={(e) => {
                                         e.preventDefault();
                                         editor.chain().unsetLink().run();
+                                        setValidationError(null);
                                         setModalMode(null);
                                     }}
                                 >
@@ -99,6 +119,7 @@ export default function LinkButton({ editor }: { editor: Editor }) {
                                 className="btn btn-secondary"
                                 onClick={(e) => {
                                     e.preventDefault();
+                                    setValidationError(null);
                                     setModalMode(null);
                                 }}
                             >

--- a/javascript/src/frontend/collab_forms/rich_text_editor/table.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/table.tsx
@@ -13,7 +13,7 @@ export function TableCaptionBookmarkButton({ editor }: { editor: Editor }) {
     const enabled = useEditorState({
         editor,
         selector: ({ editor }) => {
-            if (!editor.isInitialized) return { enabled: false, active: false };
+            if (!editor.isInitialized) return false;
             return editor.can().setTableCaptionBookmark("example");
         },
     });

--- a/javascript/src/services/csrf.ts
+++ b/javascript/src/services/csrf.ts
@@ -3,13 +3,12 @@
  */
 
 /**
- * Get CSRF token from cookie.
- * Django sets this as 'csrftoken' cookie.
+ * Get CSRF token from the server-rendered DOM.
  * @returns CSRF token string or empty string if not found
  */
 export function getCsrfToken(): string {
-    const cookie = document.cookie
-        .split("; ")
-        .find((row) => row.startsWith("csrftoken="));
-    return cookie ? cookie.split("=")[1] : "";
+    const token = document.querySelector<HTMLMetaElement>(
+        'meta[name="csrf-token"]'
+    )?.content;
+    return token ?? "";
 }

--- a/javascript/src/services/csrf.ts
+++ b/javascript/src/services/csrf.ts
@@ -4,11 +4,19 @@
 
 /**
  * Get CSRF token from the server-rendered DOM.
+ * Prefer the collab meta tag and fall back to Django's hidden form input.
  * @returns CSRF token string or empty string if not found
  */
 export function getCsrfToken(): string {
-    const token = document.querySelector<HTMLMetaElement>(
+    const metaToken = document.querySelector<HTMLMetaElement>(
         'meta[name="csrf-token"]'
     )?.content;
-    return token ?? "";
+    if (metaToken) {
+        return metaToken;
+    }
+
+    const formToken = document.querySelector<HTMLInputElement>(
+        'input[name="csrfmiddlewaretoken"]'
+    )?.value;
+    return formToken ?? "";
 }

--- a/javascript/src/tiptap_gw/link.ts
+++ b/javascript/src/tiptap_gw/link.ts
@@ -1,5 +1,36 @@
 import TTLink from "@tiptap/extension-link";
 
+const ALLOWED_LINK_PROTOCOLS = new Set(["http", "https", "mailto", "tel"]);
+const DISALLOWED_LINK_CHARS = /[\u0000-\u0020\u007f]/;
+
+export function sanitizeLinkHref(href: string): string | null {
+    const trimmedHref = href.trim();
+    if (!trimmedHref || DISALLOWED_LINK_CHARS.test(trimmedHref)) {
+        return null;
+    }
+    if (trimmedHref.startsWith("#") || trimmedHref.startsWith("?")) {
+        return trimmedHref;
+    }
+    if (
+        (trimmedHref.startsWith("/") && !trimmedHref.startsWith("//")) ||
+        trimmedHref.startsWith("./") ||
+        trimmedHref.startsWith("../")
+    ) {
+        return trimmedHref;
+    }
+
+    const schemeMatch = trimmedHref.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+    if (schemeMatch) {
+        return ALLOWED_LINK_PROTOCOLS.has(schemeMatch[1].toLowerCase())
+            ? trimmedHref
+            : null;
+    }
+    if (trimmedHref.startsWith("//")) {
+        return null;
+    }
+    return trimmedHref;
+}
+
 const Link = TTLink.extend({
     // Disable paste rules to prevent auto-linking when pasting URLs
     addPasteRules() {

--- a/local.yml
+++ b/local.yml
@@ -181,7 +181,7 @@ services:
       - HASURA_GRAPHQL_SERVER_HOSTNAME=${HASURA_GRAPHQL_SERVER_HOSTNAME}
     ports:
       - "8001:8000" # HTTP. Also reverse-proxied through nginx
-      - "9229:9229" # nodejs debugging: https://nodejs.org/en/learn/getting-started/debugging
+      - "127.0.0.1:9229:9229" # nodejs debugging: https://nodejs.org/en/learn/getting-started/debugging
 
   graphql_engine:
     build:


### PR DESCRIPTION
# CHANGELOG

## [6.3.1] - 17 April 2026

### Changed

* Restricted links in the collaborative editor to valid URL schemes (e.g., http, https, mailto)
* Changed the `to_datetime` filter to not require a format string
  * The filter will now automatically use the `DATE_FORMAT` setting when a format string is not provided
* Adjusted tag autocomplete to only offer tags already applied to objects to which the user has access

### Fixed

* Fixed an issue that prevented report archives from being created
* Fixed the table caption "Set Bookmark" command in the editor being available when it should not be

### Security

* Restored the HttpOnly flag to cookies
* Restricted collab-server inspector to localhost for development environments