### PR TITLE
Update docx.py for hyperlink bugfix

### DIFF
--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -9,7 +9,6 @@ from django.conf import settings
 
 # 3rd Party Libraries
 import docx
-from docx.enum.dml import MSO_THEME_COLOR_INDEX
 from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_COLOR_INDEX
 from docx.image.exceptions import UnrecognizedImageError
 from docx.oxml.shared import OxmlElement, qn
@@ -75,7 +74,7 @@ class HtmlToDocx(BaseHtmlToOOXML):
                 docx.oxml.shared.qn("r:id"),
                 r_id,
             )
-            
+
             # Create the inner ``w:r`` and ``w:rPr`` that hold the link text.
             # Styling must be applied to THIS run, not an outer wrapper,
             # because this is the run that contains the visible text.

--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -57,6 +57,11 @@ class HtmlToDocx(BaseHtmlToOOXML):
         if par is not None and style.get("hyperlink_url"):
             # For Word, this code is modified from this issue:
             #   https://github.com/python-openxml/python-docx/issues/384
+            # OOXML schema note: <w:hyperlink> is a valid child of <w:p>
+            # (per CT_P / EG_PContent), not of <w:r>. Wrapping it in an outer
+            # <w:r> produces malformed XML that Word silently recovers from
+            # but LibreOffice drops on import, breaking the link.
+
             # Get an ID from the ``document.xml.rels`` file
             part = par.part
             r_id = part.relate_to(
@@ -70,24 +75,41 @@ class HtmlToDocx(BaseHtmlToOOXML):
                 docx.oxml.shared.qn("r:id"),
                 r_id,
             )
-            # Create the ``w:r`` and ``w:rPr`` elements
+            
+            # Create the inner ``w:r`` and ``w:rPr`` that hold the link text.
+            # Styling must be applied to THIS run, not an outer wrapper,
+            # because this is the run that contains the visible text.
             new_run = docx.oxml.shared.OxmlElement("w:r")
             rPr = docx.oxml.shared.OxmlElement("w:rPr")
+
+            # Apply Hyperlink styling. If the template defines a "Hyperlink"
+            # character style, reference it; otherwise emit direct color +
+            # underline as a fallback so the link is visually distinguishable
+            # even without the style definition.
+            if "Hyperlink" in self.doc.styles:
+                rStyle = docx.oxml.shared.OxmlElement("w:rStyle")
+                rStyle.set(docx.oxml.shared.qn("w:val"), "Hyperlink")
+                rPr.append(rStyle)
+            else:
+                color = docx.oxml.shared.OxmlElement("w:color")
+                color.set(docx.oxml.shared.qn("w:val"), "0563C1")
+                rPr.append(color)
+                u = docx.oxml.shared.OxmlElement("w:u")
+                u.set(docx.oxml.shared.qn("w:val"), "single")
+                rPr.append(u)
+
             new_run.append(rPr)
             self.text_tracking.append_text_to_run(new_run, str(el))
             hyperlink.append(new_run)
-            # Create a new Run object and add the hyperlink into it
-            run = par.add_run()
-            run._r.append(hyperlink)
-            # A workaround for the lack of a hyperlink style
-            if "Hyperlink" in self.doc.styles:
-                try:
-                    run.style = "Hyperlink"
-                except KeyError:
-                    pass
-            else:
-                run.font.color.theme_color = MSO_THEME_COLOR_INDEX.HYPERLINK
-                run.font.underline = True
+
+            # Trigger run-tracking bookkeeping by calling add_run(), then
+            # replace the empty <w:r> it created with our <w:hyperlink>.
+            # This keeps text_tracking's state machine in sync while still
+            # producing schema-valid XML where <w:hyperlink> is a direct
+            # child of <w:p>.
+            placeholder = par.add_run()
+            placeholder._r.addprevious(hyperlink)
+            placeholder._r.getparent().remove(placeholder._r)
         else:
             super().text(el, par=par, style=style, **kwargs)
 


### PR DESCRIPTION
ensures hyperlinks populate in MS word, LibreOffice, OpenOffice, OnlyOffice, and Google Docs

This is a fix for [https://github.com/GhostManager/Ghostwriter/issues/890](https://github.com/GhostManager/Ghostwriter/issues/890)


These are all of the test cases that needed to pass (and did):

1. text before, hyperlink at end.
2. hyperlink at paragraph start.
3. mid text hyperlinks.
4. no spaces around hyperlink
5. hyperlink inside a list.
6. hyperlink after a break.
7. hyperlink followed by an evidence reference or footnote

See the screenshots below from my local install as proof. I've also confirmed that links populate correctly in all 7 cases for Word, OpenOffice, OnlyOffice, and Google Docs both when the hyperlink style is defined and when it isnt.

<img width="2890" height="1794" alt="gw-libreoffice-post-generation" src="https://github.com/user-attachments/assets/0ffc0d26-812a-403c-980b-86be0255b0da" />
<img width="1666" height="1794" alt="GW-web-ui" src="https://github.com/user-attachments/assets/24fd3007-5c1e-4e09-8d53-e0376bdef0f3" />

