### PR TITLE
Update Docker image build for GitHub dependencies

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -36,9 +36,8 @@ RUN \
 
 RUN \
   --mount=type=bind,target=/wheels,source=/wheels,from=build \
-  --mount=type=bind,target=/requirements,source=/requirements,from=build \
   --mount=type=cache,target=/root/.cache/pip \
-  pip install --find-links=/wheels -r /requirements/production.txt
+  pip install --no-index --find-links=/wheels /wheels/*.whl
 
 # Download spaCy model for passive voice detection
 # Default to English, can be overridden via SPACY_MODEL build arg

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -32,7 +32,7 @@ FROM python:3.10.20-alpine3.23
 
 RUN \
   --mount=type=cache,target=/var/cache/apk/ \
-  apk add libpq
+  apk add libpq curl
 
 RUN \
   --mount=type=bind,target=/wheels,source=/wheels,from=build \


### PR DESCRIPTION
Small change to the Dockerfile to fix builds while we are using GitHub URLs in requirements. The options are to include `git` in the final image or stop mounting requirements and use the wheels.