### PR TITLE
Hotfix: Template download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+* Fixed an authorization bypass that allowed authenticated users to download client-scoped report templates by direct URL
+  * Template downloads now use the same client access check as the template detail page
+
 ## [7.1.0] - 16 June 2026
 
 ### Added

--- a/ghostwriter/reporting/models.py
+++ b/ghostwriter/reporting/models.py
@@ -444,6 +444,13 @@ class ReportTemplate(models.Model):
     def __str__(self):
         return f"{self.name}"
 
+    def user_can_view(self, user) -> bool:
+        if not user.is_active:
+            return False
+        if user.is_privileged or self.client is None:
+            return True
+        return self.client.user_can_view(user)
+
     def get_effective_evidence_image_alignment(self, report_config):
         template_alignment = _text_choice_from_stored_value(
             EvidenceImageAlignmentOverride, self.evidence_image_alignment

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2471,12 +2471,22 @@ class ReportTemplateDownloadTests(TestCase):
     def setUpTestData(cls):
         cls.template = ReportTemplateFactory()
         cls.user = UserFactory(password=PASSWORD)
+        cls.assigned_user = UserFactory(password=PASSWORD)
+        cls.template_client = ClientFactory()
+        cls.scoped_template = ReportTemplateFactory(client=cls.template_client, protected=True)
+        ProjectAssignmentFactory(
+            project=ProjectFactory(client=cls.template_client),
+            operator=cls.assigned_user,
+        )
         cls.uri = reverse("reporting:template_download", kwargs={"pk": cls.template.pk})
+        cls.scoped_uri = reverse("reporting:template_download", kwargs={"pk": cls.scoped_template.pk})
 
     def setUp(self):
         self.client = Client()
         self.client_auth = Client()
+        self.client_assigned = Client()
         self.assertTrue(self.client_auth.login(username=self.user.username, password=PASSWORD))
+        self.assertTrue(self.client_assigned.login(username=self.assigned_user.username, password=PASSWORD))
 
     def test_view_uri_returns_desired_download(self):
         """Test default behavior downloads file (as_attachment=True)."""
@@ -2504,6 +2514,19 @@ class ReportTemplateDownloadTests(TestCase):
     def test_view_requires_login(self):
         response = self.client.get(self.uri)
         self.assertEqual(response.status_code, 302)
+
+    def test_view_denies_client_scoped_template_without_access(self):
+        response = self.client_auth.get(self.scoped_uri)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("reporting:templates"))
+
+    def test_view_allows_client_scoped_template_with_access(self):
+        response = self.client_assigned.get(self.scoped_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            f'attachment; filename="{self.scoped_template.filename}"',
+        )
 
 
 class ReportTemplateDetailViewTests(TestCase):

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -664,10 +664,7 @@ class ReportTemplateDetailView(RoleBasedAccessControlMixin, DetailView):
     template_name = "reporting/report_template_detail.html"
 
     def test_func(self):
-        client = self.get_object().client
-        if client:
-            return client.user_can_view(self.request.user)
-        return self.request.user.is_active
+        return self.get_object().user_can_view(self.request.user)
 
     def handle_no_permission(self):
         messages.error(self.request, "You do not have permission to access that.")
@@ -853,6 +850,13 @@ class ReportTemplateDownload(RoleBasedAccessControlMixin, SingleObjectMixin, Vie
     """Return the target :model:`reporting.ReportTemplate` template file for viewing or download."""
 
     model = ReportTemplate
+
+    def test_func(self):
+        return self.get_object().user_can_view(self.request.user)
+
+    def handle_no_permission(self):
+        messages.error(self.request, "You do not have permission to access that.")
+        return redirect("reporting:templates")
 
     def get(self, *args, **kwargs):
         obj = self.get_object()

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -852,14 +852,15 @@ class ReportTemplateDownload(RoleBasedAccessControlMixin, SingleObjectMixin, Vie
     model = ReportTemplate
 
     def test_func(self):
-        return self.get_object().user_can_view(self.request.user)
+        self.object = self.get_object()
+        return self.object.user_can_view(self.request.user)
 
     def handle_no_permission(self):
         messages.error(self.request, "You do not have permission to access that.")
         return redirect("reporting:templates")
 
     def get(self, *args, **kwargs):
-        obj = self.get_object()
+        obj = self.object
         file_path = obj.document.path
         if os.path.exists(file_path):
             # Detect the content type


### PR DESCRIPTION
# CHANGELOG

## [Unreleased]

### Security

* Fixed an authorization bypass that allowed authenticated users to download client-scoped report templates by direct URL
  * Template downloads now use the same client access check as the template detail page