### PR TITLE
Hotfix: Collab editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed project collaborative notes failing to load for users with project access
+  * The collaborative editor JWT is now scoped to the project so assigned users, project invitees, client invitees, managers, and admins can edit shared project notes
+
 ### Security
 
 * Fixed an authorization bypass that allowed authenticated users to download client-scoped report templates by direct URL

--- a/ghostwriter/api/tests/test_views.py
+++ b/ghostwriter/api/tests/test_views.py
@@ -4427,6 +4427,23 @@ class CheckEditPermissionsTests(TestCase):
         )
         self.assertEqual(response.status_code, 200, response.content)
 
+    def test_access_project_allowed_for_assigned_user_with_matching_collab_scope(self):
+        ProjectAssignmentFactory(project=self.project, operator=self.user)
+
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.headers(
+                self.user,
+                collab_claims=self.collab_claims(
+                    model="project",
+                    object_id=self.project.id,
+                ),
+            ),
+            data=self.data(model="project", object_id=self.project.id),
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
     def test_access_project_allowed_for_admin_with_matching_collab_scope(self):
         response = self.client.post(
             self.uri,

--- a/ghostwriter/api/tests/test_views.py
+++ b/ghostwriter/api/tests/test_views.py
@@ -4371,7 +4371,10 @@ class CheckEditPermissionsTests(TestCase):
 
     def data(self, hasura_role="user", *, model="finding", object_id=None):
         return {
-            "input": {"model": model, "id": object_id or self.finding.id},
+            "input": {
+                "model": model,
+                "id": object_id if object_id is not None else self.finding.id,
+            },
             "session_variables": {"x-hasura-role": hasura_role},
         }
 

--- a/ghostwriter/api/tests/test_views.py
+++ b/ghostwriter/api/tests/test_views.py
@@ -4326,6 +4326,7 @@ class CheckEditPermissionsTests(TestCase):
         cls.project = ProjectFactory()
         cls.user = UserFactory(password=PASSWORD)
         cls.manager = UserFactory(password=PASSWORD, role="manager")
+        cls.admin = UserFactory(password=PASSWORD, role="admin")
         cls.uri = reverse("api:check_permissions")
 
     def setUp(self):
@@ -4414,6 +4415,21 @@ class CheckEditPermissionsTests(TestCase):
             content_type="application/json",
             headers=self.headers(
                 self.manager,
+                collab_claims=self.collab_claims(
+                    model="project",
+                    object_id=self.project.id,
+                ),
+            ),
+            data=self.data(model="project", object_id=self.project.id),
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_access_project_allowed_for_admin_with_matching_collab_scope(self):
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.headers(
+                self.admin,
                 collab_claims=self.collab_claims(
                     model="project",
                     object_id=self.project.id,

--- a/ghostwriter/api/tests/test_views.py
+++ b/ghostwriter/api/tests/test_views.py
@@ -4323,6 +4323,7 @@ class CheckEditPermissionsTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.finding = FindingFactory()
+        cls.project = ProjectFactory()
         cls.user = UserFactory(password=PASSWORD)
         cls.manager = UserFactory(password=PASSWORD, role="manager")
         cls.uri = reverse("api:check_permissions")
@@ -4367,9 +4368,9 @@ class CheckEditPermissionsTests(TestCase):
             "Authorization": f"Bearer {token}",
         }
 
-    def data(self, hasura_role="user"):
+    def data(self, hasura_role="user", *, model="finding", object_id=None):
         return {
-            "input": {"model": "finding", "id": self.finding.id},
+            "input": {"model": model, "id": object_id or self.finding.id},
             "session_variables": {"x-hasura-role": hasura_role},
         }
 
@@ -4406,6 +4407,38 @@ class CheckEditPermissionsTests(TestCase):
             data=self.data(),
         )
         self.assertEquals(response.status_code, 200, response.content)
+
+    def test_access_project_allowed_with_matching_collab_scope(self):
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.headers(
+                self.manager,
+                collab_claims=self.collab_claims(
+                    model="project",
+                    object_id=self.project.id,
+                ),
+            ),
+            data=self.data(model="project", object_id=self.project.id),
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_rejects_project_access_with_empty_collab_model_scope(self):
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.headers(
+                self.manager,
+                collab_claims={
+                    utils.COLLAB_MODEL_CLAIM: "",
+                    utils.COLLAB_OBJECT_ID_CLAIM: self.project.id,
+                    utils.COLLAB_REPORT_ID_CLAIM: utils.COLLAB_NO_ID,
+                    utils.COLLAB_FINDING_ID_CLAIM: utils.COLLAB_NO_ID,
+                },
+            ),
+            data=self.data(model="project", object_id=self.project.id),
+        )
+        self.assertEqual(response.status_code, 403, response.content)
 
     def test_rejects_collab_jwt_for_different_object_scope(self):
         response = self.client.post(

--- a/ghostwriter/commandcenter/tests/test_views.py
+++ b/ghostwriter/commandcenter/tests/test_views.py
@@ -7,7 +7,12 @@ from django.test import TestCase
 # Ghostwriter Libraries
 from ghostwriter.api import utils
 from ghostwriter.commandcenter.views import CollabModelUpdate
-from ghostwriter.factories import ReportFactory, ReportFindingLinkFactory, UserFactory
+from ghostwriter.factories import (
+    ProjectFactory,
+    ReportFactory,
+    ReportFindingLinkFactory,
+    UserFactory,
+)
 
 logging.disable(logging.CRITICAL)
 
@@ -68,4 +73,14 @@ class CollabModelUpdateTests(TestCase):
         self.assertEqual(claims[utils.COLLAB_MODEL_CLAIM], "report")
         self.assertEqual(claims[utils.COLLAB_OBJECT_ID_CLAIM], report.id)
         self.assertEqual(claims[utils.COLLAB_REPORT_ID_CLAIM], report.id)
+        self.assertEqual(claims[utils.COLLAB_FINDING_ID_CLAIM], utils.COLLAB_NO_ID)
+
+    def test_project_collab_scope_uses_project_object_id(self):
+        project = ProjectFactory()
+
+        claims = CollabModelUpdate.collab_jwt_claims("project", project)
+
+        self.assertEqual(claims[utils.COLLAB_MODEL_CLAIM], "project")
+        self.assertEqual(claims[utils.COLLAB_OBJECT_ID_CLAIM], project.id)
+        self.assertEqual(claims[utils.COLLAB_REPORT_ID_CLAIM], utils.COLLAB_NO_ID)
         self.assertEqual(claims[utils.COLLAB_FINDING_ID_CLAIM], utils.COLLAB_NO_ID)

--- a/ghostwriter/rolodex/tests/test_views.py
+++ b/ghostwriter/rolodex/tests/test_views.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.utils.encoding import force_str
 
 # Ghostwriter Libraries
+from ghostwriter.api import utils
 from ghostwriter.commandcenter.models import BloodHoundConfiguration
 from ghostwriter.factories import (
     AuxServerAddressFactory,
@@ -1120,6 +1121,17 @@ class ProjectDetailViewTests(TestCase):
     def test_view_uri_exists_at_desired_location(self):
         response = self.client_mgr.get(self.uri)
         self.assertEqual(response.status_code, 200)
+
+    def test_context_data_scopes_collab_jwt_to_project(self):
+        response = self.client_mgr.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+
+        payload = utils.get_jwt_payload(response.context["collab_jwt"])
+
+        self.assertEqual(payload[utils.COLLAB_MODEL_CLAIM], "project")
+        self.assertEqual(payload[utils.COLLAB_OBJECT_ID_CLAIM], self.project.id)
+        self.assertEqual(payload[utils.COLLAB_REPORT_ID_CLAIM], utils.COLLAB_NO_ID)
+        self.assertEqual(payload[utils.COLLAB_FINDING_ID_CLAIM], utils.COLLAB_NO_ID)
 
     def test_view_requires_login_and_permissions(self):
         response = self.client.get(self.uri)

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -1709,6 +1709,7 @@ class ProjectDetailView(RoleBasedAccessControlMixin, DetailView):
             self.request.user,
             object.pk,
             None,
+            CollabModelUpdate.collab_jwt_claims("project", object),
         ))
 
         bhc = BloodHoundConfiguration.get_solo()


### PR DESCRIPTION
# CHANGELOG

## [Unreleased]

### Fixed

* Fixed project collaborative notes failing to load for users with project access
  * The collaborative editor JWT is now scoped to the project so assigned users, project invitees, client invitees, managers, and admins can edit shared project notes