### PR TITLE
Feature: Jinja2 previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added option to scope a service token by client
   * This works similarly to _All Accessible Projects_ but filters the access by one or more clients
   * The token will have access to all current and future user-accessible projects under the selected client(s)
+* Added preview modals for findings and observations on reports
+  * These now have _Preview_ buttons in their dropdown menus
+* Added jinja2 rendering to field preview modals for finding, observation, report, and project fields
+  * Continuing preview enhancements from v7.2.0, previews now render Jinja2 templating using the report context
+  * Clicking the _Preview_ buttons will now trigger the modal and a _Rendering rich text preview..._ loading message
+  * It will take a moment to generate the context and render any Jinja2
+  * If there are syntax errors, rendering will fail and there will be an error message
 
 ### Changed
 
@@ -22,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Marked the starter templates as non-required so they will not re-appear during updates and container builds if deleted
 * Adjusted the Docker service configurations to cap log file size to 30MB (maximum of 3 files * 10MB each)
   * This caps the size of all logs to ~240MB
+* Preview modals for rich-text fields now render references, captions, and client logo objects
+  * References will be represented by your figure label and a placeholder—e.g., `Figure #`
+  * Captions will also use the configured caption label and prefix and show the caption text–e.g., `Figure # — Caption Contents`
+  * Client logo objects will insert the client logo when available
+    * Logos are set to a static 6.5" width to align with Office's default width and keep very large or wide logos under control
 
 ## [7.2.0] - 30 June 2026
 

--- a/ghostwriter/commandcenter/templates/user_extra_fields/extra_field_modal.html
+++ b/ghostwriter/commandcenter/templates/user_extra_fields/extra_field_modal.html
@@ -17,9 +17,11 @@
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
-        <div class="modal-body extra-field-modal-content"{% if field_spec.type == "json" and lazy_json_url %} data-lazy-json-url="{{ lazy_json_url }}" data-json-field-name="{{ field_spec.display_name }}"{% endif %}>
+        <div class="modal-body extra-field-modal-content"{% if field_spec.type == "json" and lazy_json_url %} data-lazy-json-url="{{ lazy_json_url }}" data-json-field-name="{{ field_spec.display_name }}"{% elif field_spec.type == "rich_text" and lazy_richtext_url %} data-lazy-richtext-url="{{ lazy_richtext_url }}"{% endif %}>
           {% if field_spec.type == "json" and lazy_json_url %}
             <p class="text-muted mb-0">JSON content will load when this preview opens.</p>
+          {% elif field_spec.type == "rich_text" and lazy_richtext_url %}
+            <p class="text-muted mb-0">Rich text preview will load when this preview opens.</p>
           {% else %}
             {% include "user_extra_fields/field.html" with extra_fields=extra_fields field_spec=field_spec preview_report=preview_report %}
           {% endif %}

--- a/ghostwriter/commandcenter/templates/user_extra_fields/lazy_richtext_modal_script.html
+++ b/ghostwriter/commandcenter/templates/user_extra_fields/lazy_richtext_modal_script.html
@@ -1,0 +1,68 @@
+<script>
+  const richtextPreviewPlaceholder = '<p class="text-muted mb-0">Rich text preview will load when this preview opens.</p>';
+  const richtextPreviewLoading = (
+    '<div class="text-center text-muted py-5" role="status" aria-live="polite">' +
+    '<i class="fas fa-spinner fa-spin fa-2x mb-3" aria-hidden="true"></i>' +
+    '<p class="mb-0">Rendering rich text preview&hellip;</p>' +
+    '</div>'
+  );
+
+  $('.extra-field-modal-content[data-lazy-richtext-url]').closest('.modal').on('show.bs.modal', function () {
+    const $modal = $(this);
+    const $content = $modal.find('.extra-field-modal-content[data-lazy-richtext-url]');
+    const richtextUrl = $content.data('lazy-richtext-url');
+    const minimumLoadingMs = 350;
+    const loadId = `${Date.now()}-${Math.random()}`;
+    const abortController = window.AbortController ? new AbortController() : null;
+
+    $content.data('richtextLoadId', loadId);
+    $content.data('richtextAbortController', abortController);
+    $content.html(richtextPreviewLoading);
+    $modal.one('shown.bs.modal', function () {
+      const loadingStartedAt = performance.now();
+      requestAnimationFrame(function () {
+        fetch(richtextUrl, {
+          method: 'GET',
+          credentials: 'same-origin',
+          signal: abortController ? abortController.signal : undefined,
+        })
+          .then(response => {
+            if (!response.ok) {
+              throw new Error('Unable to render rich text preview.');
+            }
+            return response.text();
+          })
+          .then(html => {
+            const remainingLoadingMs = Math.max(0, minimumLoadingMs - (performance.now() - loadingStartedAt));
+            setTimeout(function () {
+              if ($content.data('richtextLoadId') !== loadId || !$modal.hasClass('show')) {
+                return;
+              }
+              $content.empty().html(
+                '<div class="rich-text-field-preview">' + html + '</div>'
+              );
+            }, remainingLoadingMs);
+          })
+          .catch(error => {
+            if (error.name === 'AbortError' || $content.data('richtextLoadId') !== loadId) {
+              return;
+            }
+            console.error(error);
+            $content.html('<p class="burned mb-0">Unable to render rich text preview.</p>');
+          });
+      });
+    });
+  });
+
+  $('.extra-field-modal-content[data-lazy-richtext-url]').closest('.modal').on('hide.bs.modal', function () {
+    const $content = $(this).find('.extra-field-modal-content[data-lazy-richtext-url]');
+    const abortController = $content.data('richtextAbortController');
+
+    if (abortController) {
+      abortController.abort();
+    }
+    $content.removeData('richtextAbortController');
+    $content.removeData('richtextLoadId');
+    $content.html(richtextPreviewPlaceholder);
+  });
+</script>

--- a/ghostwriter/commandcenter/templatetags/extra_fields.py
+++ b/ghostwriter/commandcenter/templatetags/extra_fields.py
@@ -1,4 +1,5 @@
 
+import html as html_module
 import json
 
 # Django Imports
@@ -8,6 +9,7 @@ from bleach.css_sanitizer import CSSSanitizer
 from django import template
 from django.conf import settings
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.html import mark_safe
 
@@ -49,73 +51,143 @@ def _sanitize_rich_text(value):
     )
 
 
-@register.filter
-def rich_text_preview(value, report=None):
-    html = _coerce_rich_text_value(value)
-    if not report:
-        return mark_safe(_sanitize_rich_text(html))
+def _expand_evidence_and_sanitize(html, report, *, client=None):
+    """
+    Expand Ghostwriter marker spans in *html* and sanitize the result.
+
+    Handles four kinds of markers produced by the Jinja2 export pipeline:
+
+    * ``data-gw-evidence`` / ``.richtext-evidence[data-evidence-id]`` –
+      replaced with the rendered evidence image/text plus caption.
+    * ``data-gw-ref`` – cross-reference to a captioned figure, rendered as
+      *"Figure #"* in the preview.
+    * ``data-gw-caption`` – figure caption prefix, rendered as
+      *"Figure #<prefix>"* using the global report configuration.
+    * ``data-gw-image`` – named image placeholder (e.g. ``CLIENT_LOGO``),
+      rendered as an ``<img>`` tag when the asset is available.
+
+    If *report* is falsy, evidence expansion is skipped but ref/caption/image
+    markers are still expanded.
+
+    Returns a safe HTML string (not yet wrapped in ``mark_safe``).
+    """
+    report_config = ReportConfiguration.get_solo()
 
     soup = bs4.BeautifulSoup(html, "html.parser")
+
+    label = report_config.label_figure
+    prefix = report_config.prefix_figure
+
+    # --- Expand data-gw-ref spans → "Figure #" ---
+    for node in soup.select("[data-gw-ref]"):
+        node.replace_with(f"{label} #")
+
+    # --- Expand data-gw-caption spans/divs → "Figure # – <caption text>" ---
+    for node in soup.select("[data-gw-caption]"):
+        inner_text = node.get_text()
+        caption_text = f"{label} #{prefix}{inner_text}"
+        if node.name in ("div", "section", "article"):
+            # Block-level caption objects need a <p> wrapper to match the
+            # rendering of inline ``{{.caption}}`` keywords (which already
+            # sit inside a <p> from the editor).
+            new_tag = soup.new_tag("p")
+            new_tag.string = caption_text
+            node.replace_with(new_tag)
+        else:
+            node.replace_with(caption_text)
+
+    # --- Expand data-gw-image divs (e.g. CLIENT_LOGO) → <img> or placeholder ---
+    _image_placeholders = {}
+    for idx, node in enumerate(soup.select("[data-gw-image]")):
+        image_name = node.get("data-gw-image", "")
+        rendered_img = None
+        if image_name == "CLIENT_LOGO" and client and client.logo:
+            logo_url = reverse("rolodex:client_logo_download", kwargs={"pk": client.pk}) + "?view=true"
+            alt = html_module.escape(client.name) + " logo"
+            rendered_img = (
+                f'<div style="text-align: center;">'
+                f'<img class="mb-3" src="{logo_url}" alt="{alt}" '
+                f'style="max-width: 6.5in; height: auto;" />'
+                f'</div>'
+            )
+        if rendered_img:
+            placeholder = f"__GW_IMAGE_PREVIEW_{idx}__"
+            _image_placeholders[placeholder] = rendered_img
+            node.replace_with(placeholder)
+        else:
+            node.decompose()
+
+    # --- Expand evidence markers ---
     evidence_nodes = soup.select(
         ".richtext-evidence[data-evidence-id], [data-gw-evidence]"
     )
-    if not evidence_nodes:
-        return mark_safe(_sanitize_rich_text(html))
-
-    evidence_ids = set()
-    for node in evidence_nodes:
-        evidence_id = node.get("data-evidence-id") or node.get("data-gw-evidence")
-        try:
-            evidence_ids.add(int(evidence_id))
-        except (TypeError, ValueError):
-            continue
-
-    evidences = {
-        evidence.pk: evidence
-        for evidence in Evidence.objects.filter(pk__in=evidence_ids, report=report)
-    }
-    report_config = ReportConfiguration.get_solo()
-    report_template = getattr(report, "docx_template", None)
-    evidence_image_alignment = report_config.evidence_image_alignment
-    evidence_image_width = report_config.evidence_image_width or 6.5
-    if report_template is not None:
-        evidence_image_alignment = report_template.get_effective_evidence_image_alignment(
-            report_config
-        )
-        evidence_image_width = report_template.get_effective_evidence_image_width(
-            report_config
-        )
-    rendered_evidence = {}
-    for evidence in evidences.values():
-        rendered_evidence[evidence.pk] = render_to_string(
-            "snippets/evidence_display.html",
-            {
-                "evidence": evidence,
-                "report_config": report_config,
-                "evidence_image_alignment": evidence_image_alignment,
-                "evidence_image_width": evidence_image_width,
-                "clickable": True,
-                "rich_text_preview": True,
-            },
-        )
-
     placeholders = {}
-    for index, node in enumerate(evidence_nodes):
-        evidence_id = node.get("data-evidence-id") or node.get("data-gw-evidence")
-        try:
-            rendered = rendered_evidence[int(evidence_id)]
-        except (KeyError, TypeError, ValueError):
-            node.decompose()
-            continue
 
-        placeholder = f"__GW_EVIDENCE_PREVIEW_{index}__"
-        placeholders[placeholder] = rendered
-        node.replace_with(placeholder)
+    if evidence_nodes and report:
+        evidence_ids = set()
+        for node in evidence_nodes:
+            evidence_id = node.get("data-evidence-id") or node.get("data-gw-evidence")
+            try:
+                evidence_ids.add(int(evidence_id))
+            except (TypeError, ValueError):
+                continue
+
+        evidences = {
+            evidence.pk: evidence
+            for evidence in Evidence.objects.filter(pk__in=evidence_ids, report=report)
+        }
+        report_template = getattr(report, "docx_template", None)
+        evidence_image_alignment = report_config.evidence_image_alignment
+        evidence_image_width = report_config.evidence_image_width or 6.5
+        if report_template is not None:
+            evidence_image_alignment = report_template.get_effective_evidence_image_alignment(
+                report_config
+            )
+            evidence_image_width = report_template.get_effective_evidence_image_width(
+                report_config
+            )
+        rendered_evidence = {}
+        for evidence in evidences.values():
+            rendered_evidence[evidence.pk] = render_to_string(
+                "snippets/evidence_display.html",
+                {
+                    "evidence": evidence,
+                    "report_config": report_config,
+                    "evidence_image_alignment": evidence_image_alignment,
+                    "evidence_image_width": evidence_image_width,
+                    "clickable": True,
+                    "rich_text_preview": True,
+                },
+            )
+
+        for index, node in enumerate(evidence_nodes):
+            evidence_id = node.get("data-evidence-id") or node.get("data-gw-evidence")
+            try:
+                rendered = rendered_evidence[int(evidence_id)]
+            except (KeyError, TypeError, ValueError):
+                node.decompose()
+                continue
+
+            placeholder = f"__GW_EVIDENCE_PREVIEW_{index}__"
+            placeholders[placeholder] = rendered
+            node.replace_with(placeholder)
+    elif evidence_nodes:
+        # No report context – remove unresolvable evidence markers
+        for node in evidence_nodes:
+            node.decompose()
 
     sanitized = _sanitize_rich_text(str(soup))
     for placeholder, rendered in placeholders.items():
         sanitized = sanitized.replace(placeholder, rendered)
-    return mark_safe(sanitized)
+    for placeholder, rendered in _image_placeholders.items():
+        sanitized = sanitized.replace(placeholder, rendered)
+    return sanitized
+
+
+@register.filter
+def rich_text_preview(value, report=None):
+    html = _coerce_rich_text_value(value)
+    return mark_safe(_expand_evidence_and_sanitize(html, report))
 
 
 @register.filter

--- a/ghostwriter/commandcenter/templatetags/extra_fields.py
+++ b/ghostwriter/commandcenter/templatetags/extra_fields.py
@@ -2,7 +2,6 @@
 import html as html_module
 import json
 
-# Django Imports
 import bleach
 import bs4
 from bleach.css_sanitizer import CSSSanitizer
@@ -51,7 +50,7 @@ def _sanitize_rich_text(value):
     )
 
 
-def _expand_evidence_and_sanitize(html, report, *, client=None):
+def expand_evidence_and_sanitize(html, report, *, client=None):
     """
     Expand Ghostwriter marker spans in *html* and sanitize the result.
 
@@ -187,7 +186,7 @@ def _expand_evidence_and_sanitize(html, report, *, client=None):
 @register.filter
 def rich_text_preview(value, report=None):
     html = _coerce_rich_text_value(value)
-    return mark_safe(_expand_evidence_and_sanitize(html, report))
+    return mark_safe(expand_evidence_and_sanitize(html, report))
 
 
 @register.filter

--- a/ghostwriter/commandcenter/utils.py
+++ b/ghostwriter/commandcenter/utils.py
@@ -1,0 +1,46 @@
+import bs4
+from django.utils.html import escape
+
+
+def render_rich_text_value(value):
+    """
+    Render a lazily-evaluated rich-text value to an HTML string.
+
+    Catches ``ReportExportTemplateError`` and returns an inline alert
+    so the preview can still display remaining fields.
+    """
+    from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+
+    if value is None:
+        return ""
+    try:
+        return str(value.__html__()) if hasattr(value, "__html__") else str(value)
+    except ReportExportTemplateError as error:
+        return (
+            f'<div class="alert alert-danger">'
+            f"<strong>Template Error</strong><br>{escape(str(error))}"
+            f"</div>"
+        )
+
+
+def has_rich_text_content(html_str):
+    """Return ``True`` if *html_str* contains visible text or marker elements."""
+    if not html_str or not html_str.strip():
+        return False
+    soup = bs4.BeautifulSoup(html_str, "html.parser")
+    if soup.get_text(strip=True):
+        return True
+    return bool(soup.select(
+        "[data-gw-evidence], [data-evidence-id], [data-gw-image], [data-gw-ref], [data-gw-caption], img"
+    ))
+
+
+def wrap_plain_value(value, html_str):
+    """Wrap non-HTML or boolean values in appropriate HTML for preview display."""
+    if isinstance(value, bool):
+        icon = "fa-check" if value else "fa-times"
+        css = "healthy" if value else "burned"
+        return f'<p><span class="{css}"><i class="fas {icon}"></i></span></p>'
+    if not hasattr(value, "__html__") and "<" not in html_str:
+        return f"<p>{escape(html_str)}</p>"
+    return html_str

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -192,11 +192,10 @@ class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMix
         return self.request.user.is_active
 
     def handle_no_permission(self):
-        return JsonResponse(
-            {
-                "result": "error",
-                "message": "You do not have permission to access that.",
-            },
+        return HttpResponse(
+            '<div class="alert alert-danger" role="alert">'
+            "You do not have permission to access that.</div>",
+            content_type="text/html",
             status=403,
         )
 

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -1,11 +1,12 @@
 
+import logging
 from typing import Any
 from datetime import datetime, timezone, timedelta
 
 from django.views import View
 from django.views.generic.detail import DetailView, SingleObjectMixin
 from django.contrib import messages
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.conf import settings
 from django.db.models import Model
@@ -24,6 +25,8 @@ from ghostwriter.api.utils import (
 )
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
 from ghostwriter.modules.custom_serializers import ExtraFieldsSpecSerializer
+
+logger = logging.getLogger(__name__)
 
 COLLAB_MODEL_NAME_MAP = {
     "reportfindinglink": "report_finding_link",
@@ -166,3 +169,122 @@ class ExtraFieldJsonView(RoleBasedAccessControlMixin, SingleObjectMixin, View):
                 "value": field.value_of(obj.extra_fields),
             }
         )
+
+
+
+class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMixin, View):
+    """
+    Return rendered rich-text HTML for an extra field, with Jinja2 template
+    variables resolved using the same export context used for report generation.
+
+    Subclasses must set ``model`` and may override ``build_exporter`` and
+    ``extract_rendered_field`` to customize context building.
+    """
+
+    def test_func(self):
+        obj = self.get_object()
+        can_view = getattr(obj, "user_can_view", None)
+        if callable(can_view):
+            return can_view(self.request.user)
+        return self.request.user.is_active
+
+    def handle_no_permission(self):
+        return JsonResponse(
+            {
+                "result": "error",
+                "message": "You do not have permission to access that.",
+            },
+            status=403,
+        )
+
+    #: Model used to look up ``ExtraFieldSpec`` entries.  Defaults to
+    #: ``self.model`` but can be overridden when the specs are registered
+    #: against a different model (e.g. ``Finding`` for ``ReportFindingLink``).
+    extra_field_spec_model = None
+
+    def build_exporter(self, obj):
+        """
+        Return an ``ExportBase`` subclass instance whose ``map_rich_texts``
+        method produces ``LazilyRenderedTemplate`` objects for rich-text
+        extra fields.
+
+        The default implementation raises ``NotImplementedError``.
+        """
+        raise NotImplementedError
+
+    def extract_rendered_field(self, exporter, base_context, field_name):
+        """
+        Navigate the processed *base_context* to find the rendered value of
+        *field_name*.  Returns an HTML string.
+
+        The default walks ``base_context["extra_fields"][field_name]``.
+        """
+        value = base_context.get("extra_fields", {}).get(field_name)
+        if value is None:
+            return ""
+        return str(value.__html__()) if hasattr(value, "__html__") else str(value)
+
+    def get_report_for_evidence(self, obj):
+        """Return a ``Report`` instance to use for evidence expansion, or ``None``."""
+        return None
+
+    def get_client(self, obj):
+        """Return the :model:`rolodex.Client` for image resolution, or ``None``."""
+        return None
+
+    def get(self, request, *args, **kwargs):
+        from django.utils.html import escape
+
+        from ghostwriter.commandcenter.templatetags.extra_fields import (
+            _expand_evidence_and_sanitize,
+        )
+        from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+
+        obj = self.get_object()
+        field_name = kwargs["extra_field_name"]
+
+        spec_model = self.extra_field_spec_model or self.model
+        field = get_object_or_404(
+            ExtraFieldSpec.for_model(spec_model),
+            internal_name=field_name,
+            type="rich_text",
+        )
+
+        try:
+            exporter = self.build_exporter(obj)
+            base_context = exporter.map_rich_texts()
+            html = self.extract_rendered_field(exporter, base_context, field_name)
+        except ReportExportTemplateError as error:
+            logger.warning(
+                "Template error rendering rich-text preview for %s field %s: %s",
+                self.model.__name__,
+                field_name,
+                error,
+            )
+            return HttpResponse(
+                '<div class="alert alert-danger" role="alert">'
+                "<strong>Template Error</strong><br>"
+                f"{escape(str(error))}"
+                "</div>",
+                content_type="text/html",
+                status=200,
+            )
+        except Exception:
+            logger.exception(
+                "Error rendering rich-text preview for %s field %s",
+                self.model.__name__,
+                field_name,
+            )
+            return HttpResponse(
+                '<div class="alert alert-danger" role="alert">'
+                "<strong>Preview Error</strong><br>"
+                "An unexpected error occurred while rendering this "
+                "rich-text preview.</div>",
+                content_type="text/html",
+                status=200,
+            )
+
+        report = self.get_report_for_evidence(obj)
+        client = self.get_client(obj)
+        sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+        return HttpResponse(sanitized, content_type="text/html")

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.conf import settings
 from django.db.models import Model
 from django.utils.decorators import method_decorator
+from django.utils.html import escape
 from django.views.decorators.csrf import requires_csrf_token
 
 from ghostwriter.api.utils import (
@@ -24,7 +25,9 @@ from ghostwriter.api.utils import (
     generate_jwt,
 )
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
+from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
 from ghostwriter.modules.custom_serializers import ExtraFieldsSpecSerializer
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
 
 logger = logging.getLogger(__name__)
 
@@ -233,13 +236,6 @@ class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMix
         return None
 
     def get(self, request, *args, **kwargs):
-        from django.utils.html import escape
-
-        from ghostwriter.commandcenter.templatetags.extra_fields import (
-            _expand_evidence_and_sanitize,
-        )
-        from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
-
         obj = self.get_object()
         field_name = kwargs["extra_field_name"]
 

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -27,7 +27,7 @@ from ghostwriter.api.utils import (
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
 from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
 from ghostwriter.modules.custom_serializers import ExtraFieldsSpecSerializer
-from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+from ghostwriter.modules.reportwriter.base import ReportExportError, ReportExportTemplateError
 
 logger = logging.getLogger(__name__)
 
@@ -265,17 +265,17 @@ class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMix
                 content_type="text/html",
                 status=200,
             )
-        except Exception:
-            logger.exception(
-                "Error rendering rich-text preview for %s field %s",
+        except ReportExportError as error:
+            logger.warning(
+                "Export error rendering rich-text preview for %s field %s: %s",
                 self.model.__name__,
                 field_name,
+                error,
             )
             return HttpResponse(
                 '<div class="alert alert-danger" role="alert">'
                 "<strong>Preview Error</strong><br>"
-                "An unexpected error occurred while rendering this "
-                "rich-text preview.</div>",
+                f"{escape(str(error))}</div>",
                 content_type="text/html",
                 status=200,
             )

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -244,7 +244,7 @@ class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMix
         field_name = kwargs["extra_field_name"]
 
         spec_model = self.extra_field_spec_model or self.model
-        field = get_object_or_404(
+        get_object_or_404(
             ExtraFieldSpec.for_model(spec_model),
             internal_name=field_name,
             type="rich_text",

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -25,7 +25,7 @@ from ghostwriter.api.utils import (
     generate_jwt,
 )
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
-from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
 from ghostwriter.modules.custom_serializers import ExtraFieldsSpecSerializer
 from ghostwriter.modules.reportwriter.base import ReportExportError, ReportExportTemplateError
 
@@ -174,7 +174,6 @@ class ExtraFieldJsonView(RoleBasedAccessControlMixin, SingleObjectMixin, View):
         )
 
 
-
 class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMixin, View):
     """
     Return rendered rich-text HTML for an extra field, with Jinja2 template
@@ -281,5 +280,5 @@ class ExtraFieldRichTextPreviewView(RoleBasedAccessControlMixin, SingleObjectMix
 
         report = self.get_report_for_evidence(obj)
         client = self.get_client(obj)
-        sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+        sanitized = expand_evidence_and_sanitize(html, report, client=client)
         return HttpResponse(sanitized, content_type="text/html")

--- a/ghostwriter/reporting/templates/reporting/finding_detail.html
+++ b/ghostwriter/reporting/templates/reporting/finding_detail.html
@@ -205,6 +205,7 @@
               {{ field_spec.get_type_display }} Field
             {% endif %}
           </div>
+          <div class="extra-field-type">Loop and reference as <code>object.extra_fields.{{ field_spec.internal_name }}</code></div>
           <div class="extra-field-value">
             {% if field_spec.type == "rich_text" %}
               <span class="extra-field-summary">Use Preview to view formatted content.</span>

--- a/ghostwriter/reporting/templates/reporting/finding_detail.html
+++ b/ghostwriter/reporting/templates/reporting/finding_detail.html
@@ -194,6 +194,8 @@
     <h4 class="icon custom-field-icon">Extra Fields</h4>
     <hr>
 
+    <p class="text-muted small">Jinja2 template syntax will not be rendered in these previews because a project and report context is needed. Rich text previews with rendered Jinja2 are available on report and project detail pages where these fields are referenced.</p>
+
     <div class="extra-fields-grid">
       {% for field_spec in finding_extra_fields_spec %}
         <section class="extra-field-card">

--- a/ghostwriter/reporting/templates/reporting/observation_detail.html
+++ b/ghostwriter/reporting/templates/reporting/observation_detail.html
@@ -64,6 +64,7 @@
               {{ field_spec.get_type_display }} Field
             {% endif %}
           </div>
+          <div class="extra-field-type">Loop and reference as <code>object.extra_fields.{{ field_spec.internal_name }}</code></div>
           <div class="extra-field-value">
             {% if field_spec.type == "rich_text" %}
               <span class="extra-field-summary">Use Preview to view formatted content.</span>

--- a/ghostwriter/reporting/templates/reporting/observation_detail.html
+++ b/ghostwriter/reporting/templates/reporting/observation_detail.html
@@ -53,6 +53,8 @@
     <h4 class="icon custom-field-icon">Extra Fields</h4>
     <hr>
 
+    <p class="text-muted small">Jinja2 template syntax will not be rendered in these previews because a project and report context is needed. Rich text previews with rendered Jinja2 are available on report and project detail pages where these fields are referenced.</p>
+
     <div class="extra-fields-grid">
       {% for field_spec in observation_extra_fields_spec %}
         <section class="extra-field-card">

--- a/ghostwriter/reporting/templates/reporting/report_detail.html
+++ b/ghostwriter/reporting/templates/reporting/report_detail.html
@@ -922,7 +922,7 @@
           <div>
             <h5 class="modal-title" id="finding-preview-modal-title">Finding Preview</h5>
             <p class="text-muted small mb-0">
-              This preview closely approximates report output using the report configuration and selected Word template settings.
+              This preview closely approximates report output using the report configuration and selected Word template settings. Only fields with content will be displayed in the preview.
             </p>
           </div>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -995,6 +995,90 @@
       findingPreviewAbortController = null;
       $('#finding-preview-modal-body').html(findingPreviewPlaceholder);
       $('#finding-preview-modal-title').text('Finding Preview');
+    });
+  </script>
+
+  {% comment %} Observation preview modal {% endcomment %}
+  <div id="observation-preview-modal" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-super-sized modal-dialog-scrollable" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <div>
+            <h5 class="modal-title" id="observation-preview-modal-title">Observation Preview</h5>
+            <p class="text-muted small mb-0">
+              This preview closely approximates report output using the report configuration and selected Word template settings. Only fields with content will be displayed in the preview.
+            </p>
+          </div>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body" id="observation-preview-modal-body">
+          <p class="text-muted mb-0">Observation preview will load when opened.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary col-3" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const observationPreviewPlaceholder = '<p class="text-muted mb-0">Observation preview will load when opened.</p>';
+    const observationPreviewLoading = (
+      '<div class="text-center text-muted py-5" role="status" aria-live="polite">' +
+      '<i class="fas fa-spinner fa-spin fa-2x mb-3" aria-hidden="true"></i>' +
+      '<p class="mb-0">Rendering observation preview&hellip;</p>' +
+      '</div>'
+    );
+
+    let observationPreviewAbortController = null;
+
+    $('#observation-preview-modal').on('show.bs.modal', function (event) {
+      const $trigger = $(event.relatedTarget);
+      const previewUrl = $trigger.data('observation-preview-url');
+      const obsTitle = $trigger.data('observation-title') || 'Observation Preview';
+      const $body = $('#observation-preview-modal-body');
+      const $title = $('#observation-preview-modal-title');
+
+      $title.text(obsTitle);
+      $body.html(observationPreviewLoading);
+      observationPreviewAbortController = window.AbortController ? new AbortController() : null;
+
+      $(this).one('shown.bs.modal', function () {
+        const loadingStartedAt = performance.now();
+        requestAnimationFrame(function () {
+          fetch(previewUrl, {
+            method: 'GET',
+            credentials: 'same-origin',
+            signal: observationPreviewAbortController ? observationPreviewAbortController.signal : undefined,
+          })
+            .then(response => {
+              if (!response.ok) throw new Error('Unable to render observation preview.');
+              return response.text();
+            })
+            .then(html => {
+              const remaining = Math.max(0, 350 - (performance.now() - loadingStartedAt));
+              setTimeout(function () {
+                if (!$('#observation-preview-modal').hasClass('show')) return;
+                $body.html('<div class="rich-text-field-preview">' + html + '</div>');
+                $body.find('[data-toggle="tooltip"]').tooltip();
+              }, remaining);
+            })
+            .catch(error => {
+              if (error.name === 'AbortError') return;
+              console.error(error);
+              $body.html('<p class="burned mb-0">Unable to render observation preview.</p>');
+            });
+        });
+      });
+    });
+
+    $('#observation-preview-modal').on('hide.bs.modal', function () {
+      if (observationPreviewAbortController) observationPreviewAbortController.abort();
+      observationPreviewAbortController = null;
+      $('#observation-preview-modal-body').html(observationPreviewPlaceholder);
+      $('#observation-preview-modal-title').text('Observation Preview');
     });
   </script>
 

--- a/ghostwriter/reporting/templates/reporting/report_detail.html
+++ b/ghostwriter/reporting/templates/reporting/report_detail.html
@@ -898,50 +898,14 @@
   {% if report_extra_fields_spec %}
     {% for field_spec in report_extra_fields_spec %}
       {% url 'reporting:report_extra_field_json' report.id field_spec.internal_name as extra_field_json_url %}
-      {% include "user_extra_fields/extra_field_modal.html" with extra_fields=report.extra_fields field_spec=field_spec preview_report=report lazy_json_url=extra_field_json_url %}
+      {% url 'reporting:report_extra_field_richtext' report.id field_spec.internal_name as extra_field_richtext_url %}
+      {% include "user_extra_fields/extra_field_modal.html" with extra_fields=report.extra_fields field_spec=field_spec preview_report=report lazy_json_url=extra_field_json_url lazy_richtext_url=extra_field_richtext_url %}
     {% endfor %}
 
     {% include "user_extra_fields/lazy_json_modal_script.html" %}
-    <script>
-      $('.extra-field-modal-content').each(function (e) {
-        if ($(this).data('lazy-json-url')) {
-          return;
-        }
-        let text = $(this).html();
-        let $previewModal = $(this);
-        for (let i = 0; i < evidenceFiles.length; i++) {
-          if (text.includes(evidenceFiles[i].text)) {
-            if (evidenceFiles[i].text.includes('caption')) {
-              console.log(evidenceFiles[i].text)
-              let re = new RegExp('<p>' + evidenceFiles[i].text, 'g');
-              text = text.replace(re, evidenceFiles[i].value);
-              console.log(text)
-              $previewModal.html(text);
-            } else {
-              $.ajaxSetup({
-                beforeSend: function (xhr, settings) {
-                  if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-                    xhr.setRequestHeader('X-CSRFToken', csrftoken);
-                  }
-                }
-              });
-              // Send AJAX POST request
-              $.ajax({
-                url: evidenceFiles[i].value,
-                type: 'GET',
-                success: function (data) {
-                  if (data) {
-                    let re = new RegExp('<p>' + evidenceFiles[i].text + '</p>', 'g');
-                    text = text.replace(re, data);
-                    $previewModal.html(text);
-                  }
-                }
-              });
-            }
-          }
-        }
-      });
+    {% include "user_extra_fields/lazy_richtext_modal_script.html" %}
 
+    <script>
       {% comment %} Store the last selected tab to return to it on page reload {% endcomment %}
       $('.nav-link').click(function () {
         let tab = $(this).attr('href');

--- a/ghostwriter/reporting/templates/reporting/report_detail.html
+++ b/ghostwriter/reporting/templates/reporting/report_detail.html
@@ -243,11 +243,11 @@
           </div>
         </form>
 
-        <p class="mt-3">Add a finding by adding a blank template below, by searching the library and then
+        <p class="mt-3 mb-1">Add a finding by adding a blank template below, by searching the library and then
           clicking the <span class="p-1 add-icon"></span> button in the results, or
           by clicking an autocomplete result above.</p>
 
-        <p class="mt-3">Drag and drop findings within a severity category to change its ordering. Edit
+        <p class="mt-0">Drag and drop findings within a severity category to change its ordering. Edit
           a finding to change its severity.</p>
 
         <button class="btn btn-primary icon add-icon col-3"
@@ -913,6 +913,90 @@
       });
     </script>
   {% endif %}
+
+  {% comment %} Finding preview modal {% endcomment %}
+  <div id="finding-preview-modal" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-super-sized modal-dialog-scrollable" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <div>
+            <h5 class="modal-title" id="finding-preview-modal-title">Finding Preview</h5>
+            <p class="text-muted small mb-0">
+              This preview closely approximates report output using the report configuration and selected Word template settings.
+            </p>
+          </div>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body" id="finding-preview-modal-body">
+          <p class="text-muted mb-0">Finding preview will load when opened.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary col-3" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const findingPreviewPlaceholder = '<p class="text-muted mb-0">Finding preview will load when opened.</p>';
+    const findingPreviewLoading = (
+      '<div class="text-center text-muted py-5" role="status" aria-live="polite">' +
+      '<i class="fas fa-spinner fa-spin fa-2x mb-3" aria-hidden="true"></i>' +
+      '<p class="mb-0">Rendering finding preview&hellip;</p>' +
+      '</div>'
+    );
+
+    let findingPreviewAbortController = null;
+
+    $('#finding-preview-modal').on('show.bs.modal', function (event) {
+      const $trigger = $(event.relatedTarget);
+      const previewUrl = $trigger.data('finding-preview-url');
+      const findingTitle = $trigger.data('finding-title') || 'Finding Preview';
+      const $body = $('#finding-preview-modal-body');
+      const $title = $('#finding-preview-modal-title');
+
+      $title.text(findingTitle);
+      $body.html(findingPreviewLoading);
+      findingPreviewAbortController = window.AbortController ? new AbortController() : null;
+
+      $(this).one('shown.bs.modal', function () {
+        const loadingStartedAt = performance.now();
+        requestAnimationFrame(function () {
+          fetch(previewUrl, {
+            method: 'GET',
+            credentials: 'same-origin',
+            signal: findingPreviewAbortController ? findingPreviewAbortController.signal : undefined,
+          })
+            .then(response => {
+              if (!response.ok) throw new Error('Unable to render finding preview.');
+              return response.text();
+            })
+            .then(html => {
+              const remaining = Math.max(0, 350 - (performance.now() - loadingStartedAt));
+              setTimeout(function () {
+                if (!$('#finding-preview-modal').hasClass('show')) return;
+                $body.html('<div class="rich-text-field-preview">' + html + '</div>');
+                $body.find('[data-toggle="tooltip"]').tooltip();
+              }, remaining);
+            })
+            .catch(error => {
+              if (error.name === 'AbortError') return;
+              console.error(error);
+              $body.html('<p class="burned mb-0">Unable to render finding preview.</p>');
+            });
+        });
+      });
+    });
+
+    $('#finding-preview-modal').on('hide.bs.modal', function () {
+      if (findingPreviewAbortController) findingPreviewAbortController.abort();
+      findingPreviewAbortController = null;
+      $('#finding-preview-modal-body').html(findingPreviewPlaceholder);
+      $('#finding-preview-modal-title').text('Finding Preview');
+    });
+  </script>
 
   {% comment %} Include the evidence lightbox modal {% endcomment %}
   {% include "snippets/evidence_lightbox_modal.html" %}

--- a/ghostwriter/reporting/templates/reporting/report_detail.html
+++ b/ghostwriter/reporting/templates/reporting/report_detail.html
@@ -381,6 +381,7 @@
                     {{ field_spec.get_type_display }} Field
                   {% endif %}
                 </div>
+                <div class="extra-field-type">Reference as <code>extra_fields.{{ field_spec.internal_name }}</code></div>
                 <div class="extra-field-value">
                   {% if field_spec.type == "rich_text" %}
                     <span class="extra-field-summary">Use Preview to view formatted content.</span>

--- a/ghostwriter/reporting/templates/snippets/report_findings_table.html
+++ b/ghostwriter/reporting/templates/snippets/report_findings_table.html
@@ -112,6 +112,10 @@
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
                 <div id="finding-dropdown-menu-{{ finding.id }}" class="dropdown-menu"
                      aria-labelledby="dns-dropdown-btn_{{ finding.id }}">
+                  <a class="dropdown-item icon view-icon js-finding-preview" href="javascript:void(0);"
+                     data-finding-preview-url="{% url 'reporting:finding_preview' finding.id %}"
+                     data-finding-title="{{ finding.title }}"
+                     data-toggle="modal" data-target="#finding-preview-modal">Preview</a>
                   <a class="dropdown-item icon edit-icon"
                      href="{% url 'reporting:local_edit' finding.id %}">Edit</a>
                   <a class="dropdown-item icon user-icon"

--- a/ghostwriter/reporting/templates/snippets/report_observations_table.html
+++ b/ghostwriter/reporting/templates/snippets/report_observations_table.html
@@ -82,6 +82,10 @@
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
             <div id="observation-dropdown-menu-{{ observation.id }}" class="dropdown-menu"
                  aria-labelledby="observation-dropdown-btn-{{ observation.id }}">
+              <a class="dropdown-item icon view-icon js-observation-preview" href="javascript:void(0);"
+                 data-observation-preview-url="{% url 'reporting:observation_preview' observation.id %}"
+                 data-observation-title="{{ observation.title }}"
+                 data-toggle="modal" data-target="#observation-preview-modal">Preview</a>
               <a class="dropdown-item icon edit-icon"
                  href="{% url 'reporting:local_observation_edit' observation.id %}">Edit</a>
               <a class="dropdown-item icon user-icon"

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2632,6 +2632,292 @@ class ReportExtraFieldEditViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class ExpandEvidenceAndSanitizeTests(TestCase):
+    """Tests for _expand_evidence_and_sanitize marker expansion."""
+
+    def test_ref_marker_expanded(self):
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        html = '<p>See <span data-gw-ref="evA"></span> for details</p>'
+        result = _expand_evidence_and_sanitize(html, None)
+        self.assertIn("Figure", result)
+        self.assertIn("#", result)
+        self.assertNotIn("data-gw-ref", result)
+
+    def test_inline_caption_marker_expanded(self):
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        html = '<p><span data-gw-caption=""></span>My Caption</p>'
+        result = _expand_evidence_and_sanitize(html, None)
+        self.assertIn("Figure", result)
+        self.assertIn("My Caption", result)
+        self.assertNotIn("data-gw-caption", result)
+
+    def test_block_caption_wrapped_in_p(self):
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        html = '<div data-gw-caption="bookmark">Caption Text</div>'
+        result = _expand_evidence_and_sanitize(html, None)
+        self.assertIn("<p>", result)
+        self.assertIn("Caption Text", result)
+        self.assertIn("Figure", result)
+
+    def test_image_marker_without_client_decomposed(self):
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        html = '<div data-gw-image="CLIENT_LOGO"></div>'
+        result = _expand_evidence_and_sanitize(html, None)
+        self.assertNotIn("CLIENT_LOGO", result)
+        self.assertNotIn("__GW_IMAGE_PREVIEW_", result)
+
+    def test_image_marker_with_client_logo(self):
+        from unittest.mock import MagicMock, PropertyMock, patch
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        client = ClientFactory()
+        logo_mock = MagicMock()
+        logo_mock.__bool__ = lambda s: True
+        logo_mock.name = "test_logo.png"
+        with patch.object(type(client), "logo", new_callable=PropertyMock, return_value=logo_mock):
+            html = '<div data-gw-image="CLIENT_LOGO"></div>'
+            result = _expand_evidence_and_sanitize(html, None, client=client)
+        self.assertIn("<img", result)
+        self.assertIn("/rolodex/clients/logo/download/", result)
+        self.assertNotIn("__GW_IMAGE_PREVIEW_", result)
+
+    def test_evidence_markers_without_report_decomposed(self):
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        html = '<p><span data-gw-evidence="999"></span></p>'
+        result = _expand_evidence_and_sanitize(html, None)
+        self.assertNotIn("data-gw-evidence", result)
+
+    def test_plain_html_passes_through(self):
+        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        html = '<p>Hello <strong>world</strong></p>'
+        result = _expand_evidence_and_sanitize(html, None)
+        self.assertIn("Hello", result)
+        self.assertIn("world", result)
+
+
+class ReportFindingLinkPreviewTests(TestCase):
+    """Tests for :view:`reporting.ReportFindingLinkPreview`."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.report = ReportFactory(
+            docx_template=ReportDocxTemplateFactory(),
+            pptx_template=ReportPptxTemplateFactory(),
+        )
+        cls.finding_ef_model = ExtraFieldModelFactory(
+            model_internal_name="reporting.Finding",
+            model_display_name="Findings",
+        )
+        cls.finding_rt_field = ExtraFieldSpecFactory(
+            internal_name="notes",
+            display_name="Finding Notes",
+            type="rich_text",
+            target_model=cls.finding_ef_model,
+        )
+        cls.rfl = ReportFindingLinkFactory(
+            report=cls.report,
+            title="Test Finding",
+            description="<p>Finding description</p>",
+            extra_fields={"notes": "<p>Extra field content</p>"},
+        )
+        cls.user = UserFactory(password=PASSWORD)
+        cls.mgr_user = UserFactory(password=PASSWORD, role="manager")
+        cls.uri = reverse("reporting:finding_preview", kwargs={"pk": cls.rfl.pk})
+
+    def setUp(self):
+        self.client = Client()
+        self.client_auth = Client()
+        self.client_mgr = Client()
+        self.assertTrue(self.client_auth.login(username=self.user.username, password=PASSWORD))
+        self.assertTrue(self.client_mgr.login(username=self.mgr_user.username, password=PASSWORD))
+
+    def test_requires_login(self):
+        response = self.client.get(self.uri)
+        self.assertEqual(response.status_code, 302)
+
+    def test_unauthorized_user_gets_403(self):
+        response = self.client_auth.get(self.uri)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response["Content-Type"], "text/html")
+
+    def test_manager_gets_200_with_content(self):
+        response = self.client_mgr.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Test Finding", content)
+        self.assertIn("Finding description", content)
+
+    def test_renders_severity_badge(self):
+        response = self.client_mgr.get(self.uri)
+        content = response.content.decode()
+        self.assertIn("badge", content)
+
+    def test_renders_extra_field_with_display_name(self):
+        response = self.client_mgr.get(self.uri)
+        content = response.content.decode()
+        self.assertIn("Finding Notes", content)
+        self.assertIn("Extra field content", content)
+
+    def test_hr_separator_after_badges(self):
+        response = self.client_mgr.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("<hr>", content)
+
+    def test_empty_fields_omitted(self):
+        rfl = ReportFindingLinkFactory(
+            report=self.report,
+            title="Empty Finding",
+            description="",
+            impact="",
+            mitigation="",
+            replication_steps="",
+            host_detection_techniques="",
+            network_detection_techniques="",
+            references="",
+        )
+        uri = reverse("reporting:finding_preview", kwargs={"pk": rfl.pk})
+        response = self.client_mgr.get(uri)
+        content = response.content.decode()
+        self.assertIn("Empty Finding", content)
+        self.assertNotIn("<h3>Description</h3>", content)
+        self.assertNotIn("<h3>Impact</h3>", content)
+
+
+class ReportObservationLinkPreviewTests(TestCase):
+    """Tests for :view:`reporting.ReportObservationLinkPreview`."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.report = ReportFactory(
+            docx_template=ReportDocxTemplateFactory(),
+            pptx_template=ReportPptxTemplateFactory(),
+        )
+        cls.obs_ef_model = ExtraFieldModelFactory(
+            model_internal_name="reporting.Observation",
+            model_display_name="Observations",
+        )
+        cls.obs_rt_field = ExtraFieldSpecFactory(
+            internal_name="obs_notes",
+            display_name="Observation Notes",
+            type="rich_text",
+            target_model=cls.obs_ef_model,
+        )
+        cls.rol = ReportObservationLinkFactory(
+            report=cls.report,
+            title="Test Observation",
+            description="<p>Observation description</p>",
+            extra_fields={"obs_notes": "<p>Observation extra</p>"},
+        )
+        cls.user = UserFactory(password=PASSWORD)
+        cls.mgr_user = UserFactory(password=PASSWORD, role="manager")
+        cls.uri = reverse("reporting:observation_preview", kwargs={"pk": cls.rol.pk})
+
+    def setUp(self):
+        self.client = Client()
+        self.client_auth = Client()
+        self.client_mgr = Client()
+        self.assertTrue(self.client_auth.login(username=self.user.username, password=PASSWORD))
+        self.assertTrue(self.client_mgr.login(username=self.mgr_user.username, password=PASSWORD))
+
+    def test_requires_login(self):
+        response = self.client.get(self.uri)
+        self.assertEqual(response.status_code, 302)
+
+    def test_unauthorized_user_gets_403_html(self):
+        response = self.client_auth.get(self.uri)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response["Content-Type"], "text/html")
+
+    def test_manager_gets_200_with_content(self):
+        response = self.client_mgr.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Test Observation", content)
+        self.assertIn("Observation description", content)
+
+    def test_renders_extra_field_with_display_name(self):
+        response = self.client_mgr.get(self.uri)
+        content = response.content.decode()
+        self.assertIn("Observation Notes", content)
+        self.assertIn("Observation extra", content)
+
+    def test_no_severity_badges(self):
+        response = self.client_mgr.get(self.uri)
+        content = response.content.decode()
+        self.assertNotIn("badge-pill", content)
+
+    def test_empty_description_omitted(self):
+        rol = ReportObservationLinkFactory(
+            report=self.report,
+            title="Empty Obs",
+            description="",
+        )
+        uri = reverse("reporting:observation_preview", kwargs={"pk": rol.pk})
+        response = self.client_mgr.get(uri)
+        content = response.content.decode()
+        self.assertIn("Empty Obs", content)
+        self.assertNotIn("<h3>Description</h3>", content)
+
+
+class ExtraFieldRichTextPreviewPermissionTests(TestCase):
+    """Tests for ExtraFieldRichTextPreviewView permission handling."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.report = ReportFactory(
+            docx_template=ReportDocxTemplateFactory(),
+            pptx_template=ReportPptxTemplateFactory(),
+        )
+        cls.extra_field_model = ExtraFieldModelFactory(
+            model_internal_name="reporting.Report",
+            model_display_name="Reports",
+        )
+        cls.rt_field = ExtraFieldSpecFactory(
+            internal_name="test_rt",
+            display_name="Test RT",
+            type="rich_text",
+            target_model=cls.extra_field_model,
+        )
+        cls.report.extra_fields = {"test_rt": "<p>content</p>"}
+        cls.report.save(update_fields=["extra_fields"])
+        cls.user = UserFactory(password=PASSWORD)
+        cls.mgr_user = UserFactory(password=PASSWORD, role="manager")
+        cls.uri = reverse(
+            "reporting:report_extra_field_richtext",
+            kwargs={"pk": cls.report.pk, "extra_field_name": "test_rt"},
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client_auth = Client()
+        self.client_mgr = Client()
+        self.assertTrue(self.client_auth.login(username=self.user.username, password=PASSWORD))
+        self.assertTrue(self.client_mgr.login(username=self.mgr_user.username, password=PASSWORD))
+
+    def test_403_returns_html_not_json(self):
+        response = self.client_auth.get(self.uri)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response["Content-Type"], "text/html")
+        self.assertIn("permission", response.content.decode())
+
+    def test_nonexistent_field_returns_404(self):
+        uri = reverse(
+            "reporting:report_extra_field_richtext",
+            kwargs={"pk": self.report.pk, "extra_field_name": "nonexistent"},
+        )
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 404)
+
+    def test_template_error_returns_200_with_error_message(self):
+        self.report.extra_fields = {"test_rt": "<p>{% for x in %}broken{% endfor %}</p>"}
+        self.report.save(update_fields=["extra_fields"])
+        response = self.client_mgr.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Error", content)
+        self.assertIn("alert-danger", content)
+
+
 # Tests related to :model:`reporting.Evidence`
 
 

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2607,7 +2607,7 @@ class ReportExtraFieldEditViewTests(TestCase):
             model_internal_name="reporting.Finding",
             defaults={"model_display_name": "Findings"},
         )
-        finding_rt_field = ExtraFieldSpecFactory(
+        ExtraFieldSpecFactory(
             internal_name="finding_notes2",
             display_name="Finding Notes 2",
             type="rich_text",

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2583,7 +2583,7 @@ class ReportExtraFieldEditViewTests(TestCase):
             model_internal_name="reporting.Finding",
             model_display_name="Findings",
         )
-        finding_rt_field = ExtraFieldSpecFactory(
+        ExtraFieldSpecFactory(
             internal_name="finding_notes",
             display_name="Finding Notes",
             type="rich_text",

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -1449,8 +1449,21 @@ class ReportDetailViewTests(TestCase):
         response = self.client_mgr.get(self.uri)
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Denial of Service")
-        self.assertContains(response, "Social Engineering")
+        # Rich text previews are now lazy-loaded via AJAX, so the modal body
+        # contains a placeholder and a data attribute pointing to the preview
+        # endpoint instead of inline-rendered content.
+        self.assertContains(response, "data-lazy-richtext-url")
+        self.assertContains(response, "extra-field-richtext/out_of_scope_activities")
+
+        # Verify the preview endpoint itself renders the list content
+        preview_url = reverse(
+            "reporting:report_extra_field_richtext",
+            kwargs={"pk": self.report.pk, "extra_field_name": "out_of_scope_activities"},
+        )
+        preview_response = self.client_mgr.get(preview_url)
+        self.assertEqual(preview_response.status_code, 200)
+        self.assertContains(preview_response, "Denial of Service")
+        self.assertContains(preview_response, "Social Engineering")
 
 
 class ReportOplogOutlineGenerateTests(TestCase):
@@ -2517,6 +2530,106 @@ class ReportExtraFieldEditViewTests(TestCase):
 
         response = self.client_mgr.get(uri)
         self.assertEqual(response.status_code, 404)
+
+    def test_richtext_preview_endpoint_requires_login_and_permissions(self):
+        uri = reverse(
+            "reporting:report_extra_field_richtext",
+            kwargs={
+                "pk": self.report.pk,
+                "extra_field_name": self.extra_field.internal_name,
+            },
+        )
+
+        response = self.client.get(uri)
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 200)
+
+    def test_richtext_preview_endpoint_rejects_non_richtext_fields(self):
+        uri = reverse(
+            "reporting:report_extra_field_richtext",
+            kwargs={
+                "pk": self.report.pk,
+                "extra_field_name": self.json_extra_field.internal_name,
+            },
+        )
+
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 404)
+
+    def test_richtext_preview_grants_access_to_assigned_user(self):
+        uri = reverse(
+            "reporting:report_extra_field_richtext",
+            kwargs={
+                "pk": self.report.pk,
+                "extra_field_name": self.extra_field.internal_name,
+            },
+        )
+
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 403)
+
+        ProjectAssignmentFactory(project=self.report.project, operator=self.user)
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 200)
+
+    def test_finding_link_richtext_preview_resolves_finding_extra_fields(self):
+        """ReportFindingLink specs are registered against Finding, not ReportFindingLink."""
+        finding_ef_model = ExtraFieldModelFactory(
+            model_internal_name="reporting.Finding",
+            model_display_name="Findings",
+        )
+        finding_rt_field = ExtraFieldSpecFactory(
+            internal_name="finding_notes",
+            display_name="Finding Notes",
+            type="rich_text",
+            target_model=finding_ef_model,
+        )
+        rfl = ReportFindingLinkFactory(
+            report=self.report,
+            extra_fields={"finding_notes": "<p>test content</p>"},
+        )
+        uri = reverse(
+            "reporting:reportfindinglink_extra_field_richtext",
+            kwargs={"pk": rfl.pk, "extra_field_name": "finding_notes"},
+        )
+
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "test content")
+
+    def test_finding_link_richtext_preview_requires_permissions(self):
+        finding_ef_model, _ = ExtraFieldModel.objects.get_or_create(
+            model_internal_name="reporting.Finding",
+            defaults={"model_display_name": "Findings"},
+        )
+        finding_rt_field = ExtraFieldSpecFactory(
+            internal_name="finding_notes2",
+            display_name="Finding Notes 2",
+            type="rich_text",
+            target_model=finding_ef_model,
+        )
+        rfl = ReportFindingLinkFactory(
+            report=self.report,
+            extra_fields={"finding_notes2": "<p>secret</p>"},
+        )
+        uri = reverse(
+            "reporting:reportfindinglink_extra_field_richtext",
+            kwargs={"pk": rfl.pk, "extra_field_name": "finding_notes2"},
+        )
+
+        response = self.client.get(uri)
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 200)
 
 
 # Tests related to :model:`reporting.Evidence`

--- a/ghostwriter/reporting/tests/test_views.py
+++ b/ghostwriter/reporting/tests/test_views.py
@@ -2633,63 +2633,63 @@ class ReportExtraFieldEditViewTests(TestCase):
 
 
 class ExpandEvidenceAndSanitizeTests(TestCase):
-    """Tests for _expand_evidence_and_sanitize marker expansion."""
+    """Tests for expand_evidence_and_sanitize marker expansion."""
 
     def test_ref_marker_expanded(self):
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         html = '<p>See <span data-gw-ref="evA"></span> for details</p>'
-        result = _expand_evidence_and_sanitize(html, None)
+        result = expand_evidence_and_sanitize(html, None)
         self.assertIn("Figure", result)
         self.assertIn("#", result)
         self.assertNotIn("data-gw-ref", result)
 
     def test_inline_caption_marker_expanded(self):
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         html = '<p><span data-gw-caption=""></span>My Caption</p>'
-        result = _expand_evidence_and_sanitize(html, None)
+        result = expand_evidence_and_sanitize(html, None)
         self.assertIn("Figure", result)
         self.assertIn("My Caption", result)
         self.assertNotIn("data-gw-caption", result)
 
     def test_block_caption_wrapped_in_p(self):
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         html = '<div data-gw-caption="bookmark">Caption Text</div>'
-        result = _expand_evidence_and_sanitize(html, None)
+        result = expand_evidence_and_sanitize(html, None)
         self.assertIn("<p>", result)
         self.assertIn("Caption Text", result)
         self.assertIn("Figure", result)
 
     def test_image_marker_without_client_decomposed(self):
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         html = '<div data-gw-image="CLIENT_LOGO"></div>'
-        result = _expand_evidence_and_sanitize(html, None)
+        result = expand_evidence_and_sanitize(html, None)
         self.assertNotIn("CLIENT_LOGO", result)
         self.assertNotIn("__GW_IMAGE_PREVIEW_", result)
 
     def test_image_marker_with_client_logo(self):
         from unittest.mock import MagicMock, PropertyMock, patch
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         client = ClientFactory()
         logo_mock = MagicMock()
         logo_mock.__bool__ = lambda s: True
         logo_mock.name = "test_logo.png"
         with patch.object(type(client), "logo", new_callable=PropertyMock, return_value=logo_mock):
             html = '<div data-gw-image="CLIENT_LOGO"></div>'
-            result = _expand_evidence_and_sanitize(html, None, client=client)
+            result = expand_evidence_and_sanitize(html, None, client=client)
         self.assertIn("<img", result)
         self.assertIn("/rolodex/clients/logo/download/", result)
         self.assertNotIn("__GW_IMAGE_PREVIEW_", result)
 
     def test_evidence_markers_without_report_decomposed(self):
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         html = '<p><span data-gw-evidence="999"></span></p>'
-        result = _expand_evidence_and_sanitize(html, None)
+        result = expand_evidence_and_sanitize(html, None)
         self.assertNotIn("data-gw-evidence", result)
 
     def test_plain_html_passes_through(self):
-        from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+        from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
         html = '<p>Hello <strong>world</strong></p>'
-        result = _expand_evidence_and_sanitize(html, None)
+        result = expand_evidence_and_sanitize(html, None)
         self.assertIn("Hello", result)
         self.assertIn("world", result)
 

--- a/ghostwriter/reporting/urls.py
+++ b/ghostwriter/reporting/urls.py
@@ -258,6 +258,11 @@ urlpatterns += [
         name="local_observation_edit",
     ),
     path(
+        "reports/observations/preview/<int:pk>",
+        ghostwriter.reporting.views2.report_observation_link.ReportObservationLinkPreview.as_view(),
+        name="observation_preview",
+    ),
+    path(
         "reports/observations/assign/<int:pk>",
         ghostwriter.reporting.views2.report_observation_link.ReportObservationLinkAssign.as_view(),
         name="local_observation_assign",

--- a/ghostwriter/reporting/urls.py
+++ b/ghostwriter/reporting/urls.py
@@ -243,6 +243,11 @@ urlpatterns += [
         name="reportfindinglink_extra_field_richtext",
     ),
     path(
+        "reports/findings/preview/<int:pk>",
+        ghostwriter.reporting.views2.report_finding_link.ReportFindingLinkPreview.as_view(),
+        name="finding_preview",
+    ),
+    path(
         "reports/findings/assign/<int:pk>",
         ghostwriter.reporting.views2.report_finding_link.ReportFindingAssign.as_view(),
         name="local_assign",

--- a/ghostwriter/reporting/urls.py
+++ b/ghostwriter/reporting/urls.py
@@ -120,6 +120,7 @@ urlpatterns += [
         ghostwriter.reporting.views2.finding.FindingExtraFieldJson.as_view(),
         name="finding_extra_field_json",
     ),
+
     path("findings/create/", ghostwriter.reporting.views2.finding.FindingCreate.as_view(), name="finding_create"),
     path("findings/update/<int:pk>", ghostwriter.reporting.views2.finding.FindingUpdate.as_view(), name="finding_update"),
     path("findings/delete/<int:pk>", ghostwriter.reporting.views2.finding.FindingDelete.as_view(), name="finding_delete"),
@@ -143,6 +144,7 @@ urlpatterns += [
         ghostwriter.reporting.views2.observations.ObservationExtraFieldJson.as_view(),
         name="observation_extra_field_json",
     ),
+
     path("observations/create/", ghostwriter.reporting.views2.observations.ObservationCreate.as_view(), name="observation_create"),
     path("observations/update/<int:pk>", ghostwriter.reporting.views2.observations.ObservationUpdate.as_view(), name="observation_update"),
     path("observations/delete/<int:pk>", ghostwriter.reporting.views2.observations.ObservationDelete.as_view(), name="observation_delete"),
@@ -180,6 +182,11 @@ urlpatterns += [
         "reports/<int:pk>/extra-field-json/<str:extra_field_name>",
         ghostwriter.reporting.views2.report.ReportExtraFieldJson.as_view(),
         name="report_extra_field_json",
+    ),
+    path(
+        "reports/<int:pk>/extra-field-richtext/<str:extra_field_name>",
+        ghostwriter.reporting.views2.report.ReportExtraFieldRichTextPreview.as_view(),
+        name="report_extra_field_richtext",
     ),
     path(
         "reports/<int:pk>/generate-oplog-outline",
@@ -229,6 +236,11 @@ urlpatterns += [
         "reports/findings/update/<int:pk>",
         ghostwriter.reporting.views2.report_finding_link.ReportFindingLinkUpdate.as_view(),
         name="local_edit",
+    ),
+    path(
+        "reports/findings/<int:pk>/extra-field-richtext/<str:extra_field_name>",
+        ghostwriter.reporting.views2.report_finding_link.ReportFindingLinkExtraFieldRichTextPreview.as_view(),
+        name="reportfindinglink_extra_field_richtext",
     ),
     path(
         "reports/findings/assign/<int:pk>",

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -30,7 +30,7 @@ from django.utils.html import strip_tags
 from channels.layers import get_channel_layer
 from ghostwriter.api.utils import RoleBasedAccessControlMixin, get_reports_list, get_templates_list, verify_user_is_privileged
 from ghostwriter.commandcenter.models import BloodHoundConfiguration, ExtraFieldSpec, ReportConfiguration
-from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldJsonView
+from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldJsonView, ExtraFieldRichTextPreviewView
 from ghostwriter.modules.exceptions import MissingTemplate
 from ghostwriter.modules.reportwriter import report_generation_queryset
 from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
@@ -567,6 +567,21 @@ class ReportExtraFieldEdit(CollabModelUpdate):
 
 class ReportExtraFieldJson(ExtraFieldJsonView):
     model = Report
+
+
+class ReportExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
+    model = Report
+
+    def build_exporter(self, obj):
+        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
+
+        return ExportReportJson(obj)
+
+    def get_report_for_evidence(self, obj):
+        return obj
+
+    def get_client(self, obj):
+        return obj.project.client
 
 
 class ReportOplogOutlineGenerate(RoleBasedAccessControlMixin, SingleObjectMixin, View):

--- a/ghostwriter/reporting/views2/report.py
+++ b/ghostwriter/reporting/views2/report.py
@@ -573,8 +573,6 @@ class ReportExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
     model = Report
 
     def build_exporter(self, obj):
-        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
-
         return ExportReportJson(obj)
 
     def get_report_for_evidence(self, obj):

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -24,7 +24,7 @@ from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlM
 from ghostwriter.commandcenter.models import ExtraFieldSpec
 from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
 from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldRichTextPreviewView
-from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+from ghostwriter.modules.reportwriter.base import ReportExportError, ReportExportTemplateError
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.reporting.forms import AssignReportFindingForm
 from ghostwriter.reporting.models import Finding, FindingType, Report, ReportFindingLink, Severity
@@ -290,16 +290,17 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
                 "</div>",
                 content_type="text/html",
             )
-        except Exception:
-            logger.exception(
-                "Error building preview for finding %s on report %s",
+        except ReportExportError as error:
+            logger.warning(
+                "Export error building preview for finding %s on report %s: %s",
                 obj.pk,
                 report.pk,
+                error,
             )
             return HttpResponse(
                 '<div class="alert alert-danger">'
                 "<strong>Preview Error</strong><br>"
-                "An unexpected error occurred.</div>",
+                f"{escape(str(error))}</div>",
                 content_type="text/html",
             )
 

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -231,8 +231,9 @@ class ReportFindingLinkExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
         return ExportReportJson(obj.report)
 
     def extract_rendered_field(self, exporter, base_context, field_name):
+        pk = self.kwargs["pk"]
         for finding in base_context.get("findings", []):
-            if finding.get("id") == self.get_object().pk:
+            if finding.get("id") == pk:
                 value = finding.get("extra_fields", {}).get(field_name)
                 if value is None:
                     return ""

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -349,9 +349,7 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
         if badges:
             parts.append(f'<div class="mb-3 text-center">{" ".join(badges)}</div>')
 
-        parts.append(
-            '<hr>'
-        )
+        parts.append("<hr>")
 
         def _render(value):
             if value is None:

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -19,7 +19,7 @@ from asgiref.sync import async_to_sync
 
 from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlMixin
 from ghostwriter.commandcenter.models import ExtraFieldSpec
-from ghostwriter.commandcenter.views import CollabModelUpdate
+from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldRichTextPreviewView
 from ghostwriter.reporting.forms import AssignReportFindingForm
 from ghostwriter.reporting.models import Finding, FindingType, Report, ReportFindingLink, Severity
 from ghostwriter.rolodex.models import ProjectAssignment
@@ -210,6 +210,37 @@ class ReportFindingLinkUpdate(CollabModelUpdate):
     template_name = "reporting/report_finding_link_update.html"
     unauthorized_redirect = "home:dashboard"
     has_extra_fields = Finding
+
+
+class ReportFindingLinkExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
+    """
+    Rich-text preview for a finding linked to a report.
+
+    Uses the full report export context so that ``project``, ``client``,
+    ``finding``, and evidence references all resolve correctly.
+    """
+    model = ReportFindingLink
+    extra_field_spec_model = Finding
+
+    def build_exporter(self, obj):
+        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
+
+        return ExportReportJson(obj.report)
+
+    def extract_rendered_field(self, exporter, base_context, field_name):
+        for finding in base_context.get("findings", []):
+            if finding.get("id") == self.get_object().pk:
+                value = finding.get("extra_fields", {}).get(field_name)
+                if value is None:
+                    return ""
+                return str(value.__html__()) if hasattr(value, "__html__") else str(value)
+        return ""
+
+    def get_report_for_evidence(self, obj):
+        return obj.report
+
+    def get_client(self, obj):
+        return obj.report.project.client
 
 
 class ReportFindingStatusUpdate(RoleBasedAccessControlMixin, SingleObjectMixin, View):

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -338,7 +338,7 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
                 "</span>"
             )
             badges.append(sev_badge)
-        if cvss_vector:
+        if cvss_vector and cvss_score not in (None, ""):
             badges.append(
                 f'<span class="badge badge-pill badge-dark"'
                 f' style="cursor: help; background-color: #{severity_color}; color: #fff;" data-toggle="tooltip"'

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -3,9 +3,10 @@ import logging
 import json
 from socket import gaierror
 
-from django.http import HttpResponseRedirect, JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
+from django.utils.html import escape
 from django.views import View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import UpdateView
@@ -241,6 +242,149 @@ class ReportFindingLinkExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
 
     def get_client(self, obj):
         return obj.report.project.client
+
+
+class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, View):
+    """Render a full preview of a reported finding with Jinja2 resolved."""
+
+    model = ReportFindingLink
+
+    def test_func(self):
+        return self.get_object().user_can_view(self.request.user)
+
+    def handle_no_permission(self):
+        return HttpResponse(
+            '<div class="alert alert-danger">You do not have permission to access that.</div>',
+            content_type="text/html",
+            status=403,
+        )
+
+    # Ordered list of (serialized field key, display label) for the preview.
+    RICH_TEXT_SECTIONS = [
+        ("affected_entities_rt", "Affected Entities"),
+        ("description_rt", "Description"),
+        ("impact_rt", "Impact"),
+        ("mitigation_rt", "Mitigation"),
+        ("replication_steps_rt", "Replication Steps"),
+        ("host_detection_techniques_rt", "Host Detection Techniques"),
+        ("network_detection_techniques_rt", "Network Detection Techniques"),
+        ("references_rt", "References"),
+    ]
+
+    def get(self, request, *args, **kwargs):
+        from ghostwriter.commandcenter.templatetags.extra_fields import (
+            _expand_evidence_and_sanitize,
+        )
+        from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
+
+        obj = self.get_object()
+        report = obj.report
+        client = report.project.client
+
+        try:
+            exporter = ExportReportJson(report)
+            base_context = exporter.map_rich_texts()
+        except ReportExportTemplateError as error:
+            return HttpResponse(
+                '<div class="alert alert-danger">'
+                f"<strong>Template Error</strong><br>{escape(str(error))}"
+                "</div>",
+                content_type="text/html",
+            )
+        except Exception:
+            logger.exception(
+                "Error building preview for finding %s on report %s",
+                obj.pk,
+                report.pk,
+            )
+            return HttpResponse(
+                '<div class="alert alert-danger">'
+                "<strong>Preview Error</strong><br>"
+                "An unexpected error occurred.</div>",
+                content_type="text/html",
+            )
+
+        finding_data = None
+        for f in base_context.get("findings", []):
+            if f.get("id") == obj.pk:
+                finding_data = f
+                break
+
+        if finding_data is None:
+            return HttpResponse(
+                '<div class="alert alert-warning">Finding not found in report data.</div>',
+                content_type="text/html",
+            )
+
+        parts = []
+        title = escape(finding_data.get("title", "Untitled Finding"))
+        severity = escape(str(finding_data.get("severity", "")))
+        severity_color = escape(str(finding_data.get("severity_color", "6c757d")))
+        cvss_score = finding_data.get("cvss_score")
+        cvss_vector = escape(str(finding_data.get("cvss_vector", "")))
+        finding_type = escape(str(finding_data.get("finding_type", "")))
+
+        parts.append(f"<h2>{title}</h2>")
+
+        badges = []
+        if severity:
+            sev_badge = (
+                f'<span class="badge badge-pill" '
+                f'style="background-color: #{severity_color}; color: #fff;">'
+                f"{severity}"
+                "</span>"
+            )
+            badges.append(sev_badge)
+        if cvss_vector:
+            badges.append(
+                f'<span class="badge badge-pill badge-dark"'
+                f' style="cursor: help; background-color: #{severity_color}; color: #fff;" data-toggle="tooltip"'
+                f' data-placement="bottom" title="{cvss_vector}">'
+                f"CVSS: {cvss_score}</span>"
+            )
+        if finding_type:
+            badges.append(
+                f'<span class="badge badge-pill badge-primary">{finding_type}</span>'
+            )
+        if badges:
+            parts.append(f'<div class="mb-3 text-center">{" ".join(badges)}</div>')
+
+        for key, label in self.RICH_TEXT_SECTIONS:
+            value = finding_data.get(key)
+            if value is None:
+                continue
+            try:
+                html = str(value.__html__()) if hasattr(value, "__html__") else str(value)
+            except ReportExportTemplateError as error:
+                html = (
+                    f'<div class="alert alert-danger">'
+                    f"<strong>Template Error</strong><br>{escape(str(error))}"
+                    f"</div>"
+                )
+            if html.strip():
+                sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+                parts.append(f"<h3>{escape(label)}</h3>")
+                parts.append(sanitized)
+
+        extra_fields = finding_data.get("extra_fields", {})
+        for ef_key, ef_value in extra_fields.items():
+            if ef_value is None:
+                continue
+            try:
+                html = str(ef_value.__html__()) if hasattr(ef_value, "__html__") else str(ef_value)
+            except ReportExportTemplateError as error:
+                html = (
+                    f'<div class="alert alert-danger">'
+                    f"<strong>Template Error</strong><br>{escape(str(error))}"
+                    f"</div>"
+                )
+            if html.strip():
+                sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+                parts.append(f"<h3>{escape(ef_key)}</h3>")
+                parts.append(sanitized)
+
+        return HttpResponse("\n".join(parts), content_type="text/html")
 
 
 class ReportFindingStatusUpdate(RoleBasedAccessControlMixin, SingleObjectMixin, View):

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -3,6 +3,8 @@ import logging
 import json
 from socket import gaierror
 
+import bs4
+
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -350,39 +352,58 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
         if badges:
             parts.append(f'<div class="mb-3 text-center">{" ".join(badges)}</div>')
 
-        for key, label in self.RICH_TEXT_SECTIONS:
-            value = finding_data.get(key)
+        parts.append(
+            '<hr>'
+        )
+
+        def _render(value):
             if value is None:
-                continue
+                return ""
             try:
-                html = str(value.__html__()) if hasattr(value, "__html__") else str(value)
+                return str(value.__html__()) if hasattr(value, "__html__") else str(value)
             except ReportExportTemplateError as error:
-                html = (
+                return (
                     f'<div class="alert alert-danger">'
                     f"<strong>Template Error</strong><br>{escape(str(error))}"
                     f"</div>"
                 )
-            if html.strip():
-                sanitized = _expand_evidence_and_sanitize(html, report, client=client)
-                parts.append(f"<h3>{escape(label)}</h3>")
-                parts.append(sanitized)
+
+        def _has_content(html_str):
+            if not html_str or not html_str.strip():
+                return False
+            return bool(bs4.BeautifulSoup(html_str, "html.parser").get_text(strip=True))
+
+        def _wrap_plain(value, html_str):
+            if isinstance(value, bool):
+                icon = "fa-check" if value else "fa-times"
+                css = "healthy" if value else "burned"
+                return f'<p><span class="{css}"><i class="fas {icon}"></i></span></p>'
+            if not hasattr(value, "__html__") and "<" not in html_str:
+                return f"<p>{escape(html_str)}</p>"
+            return html_str
+
+        for key, label in self.RICH_TEXT_SECTIONS:
+            html = _render(finding_data.get(key))
+            if not _has_content(html):
+                continue
+            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            parts.append(f"<h3>{escape(label)}</h3>")
+            parts.append(sanitized)
 
         extra_fields = finding_data.get("extra_fields", {})
+        ef_display_names = {
+            spec.internal_name: spec.display_name
+            for spec in ExtraFieldSpec.objects.filter(target_model=Finding._meta.label)
+        }
         for ef_key, ef_value in extra_fields.items():
-            if ef_value is None:
+            html = _render(ef_value)
+            if not _has_content(html):
                 continue
-            try:
-                html = str(ef_value.__html__()) if hasattr(ef_value, "__html__") else str(ef_value)
-            except ReportExportTemplateError as error:
-                html = (
-                    f'<div class="alert alert-danger">'
-                    f"<strong>Template Error</strong><br>{escape(str(error))}"
-                    f"</div>"
-                )
-            if html.strip():
-                sanitized = _expand_evidence_and_sanitize(html, report, client=client)
-                parts.append(f"<h3>{escape(ef_key)}</h3>")
-                parts.append(sanitized)
+            html = _wrap_plain(ef_value, html)
+            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            label = escape(ef_display_names.get(ef_key, ef_key))
+            parts.append(f"<h3>{label}</h3>")
+            parts.append(sanitized)
 
         return HttpResponse("\n".join(parts), content_type="text/html")
 

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -3,8 +3,6 @@ import logging
 import json
 from socket import gaierror
 
-import bs4
-
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -22,7 +20,8 @@ from asgiref.sync import async_to_sync
 
 from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlMixin
 from ghostwriter.commandcenter.models import ExtraFieldSpec
-from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
+from ghostwriter.commandcenter.utils import has_rich_text_content, render_rich_text_value, wrap_plain_value
 from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldRichTextPreviewView
 from ghostwriter.modules.reportwriter.base import ReportExportError, ReportExportTemplateError
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
@@ -351,42 +350,11 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
 
         parts.append("<hr>")
 
-        def _render(value):
-            if value is None:
-                return ""
-            try:
-                return str(value.__html__()) if hasattr(value, "__html__") else str(value)
-            except ReportExportTemplateError as error:
-                return (
-                    f'<div class="alert alert-danger">'
-                    f"<strong>Template Error</strong><br>{escape(str(error))}"
-                    f"</div>"
-                )
-
-        def _has_content(html_str):
-            if not html_str or not html_str.strip():
-                return False
-            soup = bs4.BeautifulSoup(html_str, "html.parser")
-            if soup.get_text(strip=True):
-                return True
-            return bool(soup.select(
-                "[data-gw-evidence], [data-evidence-id], [data-gw-image], [data-gw-ref], [data-gw-caption], img"
-            ))
-
-        def _wrap_plain(value, html_str):
-            if isinstance(value, bool):
-                icon = "fa-check" if value else "fa-times"
-                css = "healthy" if value else "burned"
-                return f'<p><span class="{css}"><i class="fas {icon}"></i></span></p>'
-            if not hasattr(value, "__html__") and "<" not in html_str:
-                return f"<p>{escape(html_str)}</p>"
-            return html_str
-
         for key, label in self.RICH_TEXT_SECTIONS:
-            html = _render(finding_data.get(key))
-            if not _has_content(html):
+            html = render_rich_text_value(finding_data.get(key))
+            if not has_rich_text_content(html):
                 continue
-            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            sanitized = expand_evidence_and_sanitize(html, report, client=client)
             parts.append(f"<h3>{escape(label)}</h3>")
             parts.append(sanitized)
 
@@ -396,11 +364,11 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
             for spec in ExtraFieldSpec.objects.filter(target_model=Finding._meta.label)
         }
         for ef_key, ef_value in extra_fields.items():
-            html = _render(ef_value)
-            if not _has_content(html):
+            html = render_rich_text_value(ef_value)
+            if not has_rich_text_content(html):
                 continue
-            html = _wrap_plain(ef_value, html)
-            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            html = wrap_plain_value(ef_value, html)
+            sanitized = expand_evidence_and_sanitize(html, report, client=client)
             label = escape(ef_display_names.get(ef_key, ef_key))
             parts.append(f"<h3>{label}</h3>")
             parts.append(sanitized)

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -22,7 +22,10 @@ from asgiref.sync import async_to_sync
 
 from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlMixin
 from ghostwriter.commandcenter.models import ExtraFieldSpec
+from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
 from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldRichTextPreviewView
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.reporting.forms import AssignReportFindingForm
 from ghostwriter.reporting.models import Finding, FindingType, Report, ReportFindingLink, Severity
 from ghostwriter.rolodex.models import ProjectAssignment
@@ -226,8 +229,6 @@ class ReportFindingLinkExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
     extra_field_spec_model = Finding
 
     def build_exporter(self, obj):
-        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
-
         return ExportReportJson(obj.report)
 
     def extract_rendered_field(self, exporter, base_context, field_name):
@@ -275,12 +276,6 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
     ]
 
     def get(self, request, *args, **kwargs):
-        from ghostwriter.commandcenter.templatetags.extra_fields import (
-            _expand_evidence_and_sanitize,
-        )
-        from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
-        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
-
         obj = self.get_object()
         report = obj.report
         client = report.project.client

--- a/ghostwriter/reporting/views2/report_finding_link.py
+++ b/ghostwriter/reporting/views2/report_finding_link.py
@@ -371,7 +371,12 @@ class ReportFindingLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, V
         def _has_content(html_str):
             if not html_str or not html_str.strip():
                 return False
-            return bool(bs4.BeautifulSoup(html_str, "html.parser").get_text(strip=True))
+            soup = bs4.BeautifulSoup(html_str, "html.parser")
+            if soup.get_text(strip=True):
+                return True
+            return bool(soup.select(
+                "[data-gw-evidence], [data-evidence-id], [data-gw-image], [data-gw-ref], [data-gw-caption], img"
+            ))
 
         def _wrap_plain(value, html_str):
             if isinstance(value, bool):

--- a/ghostwriter/reporting/views2/report_observation_link.py
+++ b/ghostwriter/reporting/views2/report_observation_link.py
@@ -24,7 +24,7 @@ from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlM
 from ghostwriter.commandcenter.models import ExtraFieldSpec
 from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
 from ghostwriter.commandcenter.views import CollabModelUpdate
-from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+from ghostwriter.modules.reportwriter.base import ReportExportError, ReportExportTemplateError
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.reporting.forms import AssignReportObservationForm
 from ghostwriter.reporting.models import Observation, Report, ReportObservationLink
@@ -253,16 +253,17 @@ class ReportObservationLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixi
                 "</div>",
                 content_type="text/html",
             )
-        except Exception:
-            logger.exception(
-                "Error building preview for observation %s on report %s",
+        except ReportExportError as error:
+            logger.warning(
+                "Export error building preview for observation %s on report %s: %s",
                 obj.pk,
                 report.pk,
+                error,
             )
             return HttpResponse(
                 '<div class="alert alert-danger">'
                 "<strong>Preview Error</strong><br>"
-                "An unexpected error occurred.</div>",
+                f"{escape(str(error))}</div>",
                 content_type="text/html",
             )
 

--- a/ghostwriter/reporting/views2/report_observation_link.py
+++ b/ghostwriter/reporting/views2/report_observation_link.py
@@ -3,13 +3,15 @@ import json
 import logging
 from socket import gaierror
 
+import bs4
+
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.db.models import Max
-from django.http import HttpRequest, HttpResponseRedirect, JsonResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -215,6 +217,126 @@ class ReportObservationLinkUpdate(CollabModelUpdate):
     template_name = "reporting/report_observation_link_update.html"
     unauthorized_redirect = "home:dashboard"
     has_extra_fields = Observation
+
+
+class ReportObservationLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixin, View):
+    """Render a full preview of a reported observation with Jinja2 resolved."""
+
+    model = ReportObservationLink
+
+    def test_func(self):
+        return self.get_object().user_can_view(self.request.user)
+
+    def handle_no_permission(self):
+        return HttpResponse(
+            '<div class="alert alert-danger">You do not have permission to access that.</div>',
+            content_type="text/html",
+            status=403,
+        )
+
+    def get(self, request, *args, **kwargs):
+        from django.utils.html import escape
+
+        from ghostwriter.commandcenter.templatetags.extra_fields import (
+            _expand_evidence_and_sanitize,
+        )
+        from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
+
+        obj = self.get_object()
+        report = obj.report
+        client = report.project.client
+
+        try:
+            exporter = ExportReportJson(report)
+            base_context = exporter.map_rich_texts()
+        except ReportExportTemplateError as error:
+            return HttpResponse(
+                '<div class="alert alert-danger">'
+                f"<strong>Template Error</strong><br>{escape(str(error))}"
+                "</div>",
+                content_type="text/html",
+            )
+        except Exception:
+            logger.exception(
+                "Error building preview for observation %s on report %s",
+                obj.pk,
+                report.pk,
+            )
+            return HttpResponse(
+                '<div class="alert alert-danger">'
+                "<strong>Preview Error</strong><br>"
+                "An unexpected error occurred.</div>",
+                content_type="text/html",
+            )
+
+        obs_data = None
+        for o in base_context.get("observations", []):
+            if o.get("id") == obj.pk:
+                obs_data = o
+                break
+
+        if obs_data is None:
+            return HttpResponse(
+                '<div class="alert alert-warning">Observation not found in report data.</div>',
+                content_type="text/html",
+            )
+
+        def _render(value):
+            if value is None:
+                return ""
+            try:
+                return str(value.__html__()) if hasattr(value, "__html__") else str(value)
+            except ReportExportTemplateError as error:
+                return (
+                    f'<div class="alert alert-danger">'
+                    f"<strong>Template Error</strong><br>{escape(str(error))}"
+                    f"</div>"
+                )
+
+        def _has_content(html_str):
+            if not html_str or not html_str.strip():
+                return False
+            return bool(bs4.BeautifulSoup(html_str, "html.parser").get_text(strip=True))
+
+        def _wrap_plain(value, html_str):
+            if isinstance(value, bool):
+                icon = "fa-check" if value else "fa-times"
+                css = "healthy" if value else "burned"
+                return f'<p><span class="{css}"><i class="fas {icon}"></i></span></p>'
+            if not hasattr(value, "__html__") and "<" not in html_str:
+                return f"<p>{escape(html_str)}</p>"
+            return html_str
+
+        parts = []
+        title = escape(obs_data.get("title", "Untitled Observation"))
+        parts.append(f"<h2>{title}</h2>")
+        parts.append(
+            '<hr>'
+        )
+
+        html = _render(obs_data.get("description_rt"))
+        if _has_content(html):
+            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            parts.append("<h3>Description</h3>")
+            parts.append(sanitized)
+
+        extra_fields = obs_data.get("extra_fields", {})
+        ef_display_names = {
+            spec.internal_name: spec.display_name
+            for spec in ExtraFieldSpec.objects.filter(target_model=Observation._meta.label)
+        }
+        for ef_key, ef_value in extra_fields.items():
+            html = _render(ef_value)
+            if not _has_content(html):
+                continue
+            html = _wrap_plain(ef_value, html)
+            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            label = escape(ef_display_names.get(ef_key, ef_key))
+            parts.append(f"<h3>{label}</h3>")
+            parts.append(sanitized)
+
+        return HttpResponse("\n".join(parts), content_type="text/html")
 
 
 @login_required

--- a/ghostwriter/reporting/views2/report_observation_link.py
+++ b/ghostwriter/reporting/views2/report_observation_link.py
@@ -297,7 +297,12 @@ class ReportObservationLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixi
         def _has_content(html_str):
             if not html_str or not html_str.strip():
                 return False
-            return bool(bs4.BeautifulSoup(html_str, "html.parser").get_text(strip=True))
+            soup = bs4.BeautifulSoup(html_str, "html.parser")
+            if soup.get_text(strip=True):
+                return True
+            return bool(soup.select(
+                "[data-gw-evidence], [data-evidence-id], [data-gw-image], [data-gw-ref], [data-gw-caption], img"
+            ))
 
         def _wrap_plain(value, html_str):
             if isinstance(value, bool):

--- a/ghostwriter/reporting/views2/report_observation_link.py
+++ b/ghostwriter/reporting/views2/report_observation_link.py
@@ -3,8 +3,6 @@ import json
 import logging
 from socket import gaierror
 
-import bs4
-
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.contrib import messages
@@ -22,7 +20,8 @@ from django.views.generic.edit import UpdateView
 
 from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlMixin
 from ghostwriter.commandcenter.models import ExtraFieldSpec
-from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
+from ghostwriter.commandcenter.templatetags.extra_fields import expand_evidence_and_sanitize
+from ghostwriter.commandcenter.utils import has_rich_text_content, render_rich_text_value, wrap_plain_value
 from ghostwriter.commandcenter.views import CollabModelUpdate
 from ghostwriter.modules.reportwriter.base import ReportExportError, ReportExportTemplateError
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
@@ -279,47 +278,14 @@ class ReportObservationLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixi
                 content_type="text/html",
             )
 
-        def _render(value):
-            if value is None:
-                return ""
-            try:
-                return str(value.__html__()) if hasattr(value, "__html__") else str(value)
-            except ReportExportTemplateError as error:
-                return (
-                    f'<div class="alert alert-danger">'
-                    f"<strong>Template Error</strong><br>{escape(str(error))}"
-                    f"</div>"
-                )
-
-        def _has_content(html_str):
-            if not html_str or not html_str.strip():
-                return False
-            soup = bs4.BeautifulSoup(html_str, "html.parser")
-            if soup.get_text(strip=True):
-                return True
-            return bool(soup.select(
-                "[data-gw-evidence], [data-evidence-id], [data-gw-image], [data-gw-ref], [data-gw-caption], img"
-            ))
-
-        def _wrap_plain(value, html_str):
-            if isinstance(value, bool):
-                icon = "fa-check" if value else "fa-times"
-                css = "healthy" if value else "burned"
-                return f'<p><span class="{css}"><i class="fas {icon}"></i></span></p>'
-            if not hasattr(value, "__html__") and "<" not in html_str:
-                return f"<p>{escape(html_str)}</p>"
-            return html_str
-
         parts = []
         title = escape(obs_data.get("title", "Untitled Observation"))
         parts.append(f"<h2>{title}</h2>")
-        parts.append(
-            '<hr>'
-        )
+        parts.append("<hr>")
 
-        html = _render(obs_data.get("description_rt"))
-        if _has_content(html):
-            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+        html = render_rich_text_value(obs_data.get("description_rt"))
+        if has_rich_text_content(html):
+            sanitized = expand_evidence_and_sanitize(html, report, client=client)
             parts.append("<h3>Description</h3>")
             parts.append(sanitized)
 
@@ -329,11 +295,11 @@ class ReportObservationLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixi
             for spec in ExtraFieldSpec.objects.filter(target_model=Observation._meta.label)
         }
         for ef_key, ef_value in extra_fields.items():
-            html = _render(ef_value)
-            if not _has_content(html):
+            html = render_rich_text_value(ef_value)
+            if not has_rich_text_content(html):
                 continue
-            html = _wrap_plain(ef_value, html)
-            sanitized = _expand_evidence_and_sanitize(html, report, client=client)
+            html = wrap_plain_value(ef_value, html)
+            sanitized = expand_evidence_and_sanitize(html, report, client=client)
             label = escape(ef_display_names.get(ef_key, ef_key))
             parts.append(f"<h3>{label}</h3>")
             parts.append(sanitized)

--- a/ghostwriter/reporting/views2/report_observation_link.py
+++ b/ghostwriter/reporting/views2/report_observation_link.py
@@ -15,13 +15,17 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonRes
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.html import escape
 from django.views import View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import UpdateView
 
 from ghostwriter.api.utils import ForbiddenJsonResponse, RoleBasedAccessControlMixin
 from ghostwriter.commandcenter.models import ExtraFieldSpec
+from ghostwriter.commandcenter.templatetags.extra_fields import _expand_evidence_and_sanitize
 from ghostwriter.commandcenter.views import CollabModelUpdate
+from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
+from ghostwriter.modules.reportwriter.report.json import ExportReportJson
 from ghostwriter.reporting.forms import AssignReportObservationForm
 from ghostwriter.reporting.models import Observation, Report, ReportObservationLink
 from ghostwriter.rolodex.models import ProjectAssignment
@@ -235,14 +239,6 @@ class ReportObservationLinkPreview(RoleBasedAccessControlMixin, SingleObjectMixi
         )
 
     def get(self, request, *args, **kwargs):
-        from django.utils.html import escape
-
-        from ghostwriter.commandcenter.templatetags.extra_fields import (
-            _expand_evidence_and_sanitize,
-        )
-        from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
-        from ghostwriter.modules.reportwriter.report.json import ExportReportJson
-
         obj = self.get_object()
         report = obj.report
         client = report.project.client

--- a/ghostwriter/rolodex/templates/rolodex/client_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/client_detail.html
@@ -406,6 +406,8 @@
           <h4>Extra Fields</h4>
           <hr/>
 
+          <p class="text-muted small">Jinja2 template syntax will not be rendered in these previews because a project and report context is needed. Rich text previews with rendered Jinja2 are available on report and project detail pages where these fields are referenced.</p>
+
           <div class="extra-fields-grid">
             {% for field_spec in client_extra_fields_spec %}
               <section class="extra-field-card">

--- a/ghostwriter/rolodex/templates/rolodex/client_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/client_detail.html
@@ -417,6 +417,7 @@
                     {{ field_spec.get_type_display }} Field
                   {% endif %}
                 </div>
+                <div class="extra-field-type">Reference as <code>client.extra_fields.{{ field_spec.internal_name }}</code></div>
                 <div class="extra-field-value">
                   {% if field_spec.type == "rich_text" %}
                     <span class="extra-field-summary">Use Preview to view formatted content.</span>

--- a/ghostwriter/rolodex/templates/rolodex/project_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/project_detail.html
@@ -1169,6 +1169,7 @@
                     {{ field_spec.get_type_display }} Field
                   {% endif %}
                 </div>
+                <div class="extra-field-type">Reference as <code>project.extra_fields.{{ field_spec.internal_name }}</code></div>
                 <div class="extra-field-value">
                   {% if field_spec.type == "rich_text" %}
                     <span class="extra-field-summary">Use Preview to view formatted content.</span>

--- a/ghostwriter/rolodex/templates/rolodex/project_detail.html
+++ b/ghostwriter/rolodex/templates/rolodex/project_detail.html
@@ -2194,9 +2194,11 @@
   {% if project_extra_fields_spec %}
     {% for field_spec in project_extra_fields_spec %}
       {% url 'rolodex:project_extra_field_json' project.id field_spec.internal_name as extra_field_json_url %}
-      {% include "user_extra_fields/extra_field_modal.html" with extra_fields=project.extra_fields field_spec=field_spec lazy_json_url=extra_field_json_url preview_report=False %}
+      {% url 'rolodex:project_extra_field_richtext' project.id field_spec.internal_name as extra_field_richtext_url %}
+      {% include "user_extra_fields/extra_field_modal.html" with extra_fields=project.extra_fields field_spec=field_spec lazy_json_url=extra_field_json_url lazy_richtext_url=extra_field_richtext_url preview_report=False %}
     {% endfor %}
     {% include "user_extra_fields/lazy_json_modal_script.html" %}
+    {% include "user_extra_fields/lazy_richtext_modal_script.html" %}
   {% endif %}
 
   {% comment %} Insert modals for additional infrastructure entry details {% endcomment %}

--- a/ghostwriter/rolodex/templates/snippets/client_nav_tabs.html
+++ b/ghostwriter/rolodex/templates/snippets/client_nav_tabs.html
@@ -26,6 +26,11 @@
         Infrastructure History <span class="badge badge-pill badge-light">{{ client.project_set.history_set.all.count }}</span>
     </a>
 </li>
+<li class="nav-item">
+    <a id="id_notes" class="nav-link tab-icon comment-icon" data-toggle="tab" href="#notes">
+        Notes <span class="badge badge-pill badge-light">{{ client.clientnote_set.all.count }}</span>
+    </a>
+</li>
 {% if client_extra_fields_spec %}
     <li class="nav-item">
         <a id="id_extra_fields" class="nav-link tab-icon custom-field-icon" data-toggle="tab" href="#extra-fields">
@@ -33,8 +38,3 @@
         </a>
     </li>
 {% endif %}
-<li class="nav-item">
-    <a id="id_notes" class="nav-link tab-icon comment-icon" data-toggle="tab" href="#notes">
-        Notes <span class="badge badge-pill badge-light">{{ client.clientnote_set.all.count }}</span>
-    </a>
-</li>

--- a/ghostwriter/rolodex/tests/test_views.py
+++ b/ghostwriter/rolodex/tests/test_views.py
@@ -1128,9 +1128,16 @@ class ProjectDetailViewTests(TestCase):
             type="json",
             target_model=cls.extra_field_model,
         )
+        cls.richtext_extra_field = ExtraFieldSpecFactory(
+            internal_name="notes",
+            display_name="Notes",
+            type="rich_text",
+            target_model=cls.extra_field_model,
+        )
         cls.project.extra_fields = {
             "summary": "Project summary",
             "testJSON": {"large": ["value", {"nested": "content"}]},
+            "notes": "<p>Test notes</p>",
         }
         cls.project.save(update_fields=["extra_fields"])
         cls.uri = reverse("rolodex:project_detail", kwargs={"pk": cls.project.pk})
@@ -1238,6 +1245,72 @@ class ProjectDetailViewTests(TestCase):
 
         response = self.client_mgr.get(uri)
         self.assertEqual(response.status_code, 404)
+
+    def test_richtext_preview_endpoint_requires_login_and_permissions(self):
+        uri = reverse(
+            "rolodex:project_extra_field_richtext",
+            kwargs={
+                "pk": self.project.pk,
+                "extra_field_name": self.richtext_extra_field.internal_name,
+            },
+        )
+
+        response = self.client.get(uri)
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 200)
+
+    def test_richtext_preview_endpoint_rejects_non_richtext_fields(self):
+        uri = reverse(
+            "rolodex:project_extra_field_richtext",
+            kwargs={
+                "pk": self.project.pk,
+                "extra_field_name": self.json_extra_field.internal_name,
+            },
+        )
+
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 404)
+
+    def test_richtext_preview_grants_access_to_assigned_user(self):
+        uri = reverse(
+            "rolodex:project_extra_field_richtext",
+            kwargs={
+                "pk": self.project.pk,
+                "extra_field_name": self.richtext_extra_field.internal_name,
+            },
+        )
+
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 403)
+
+        ProjectAssignmentFactory(project=self.project, operator=self.user)
+        response = self.client_auth.get(uri)
+        self.assertEqual(response.status_code, 200)
+
+    def test_richtext_preview_renders_client_logo_without_report_context(self):
+        """CLIENT_LOGO should render as an <img> even when report is None."""
+        self.project.extra_fields["notes"] = '<div data-gw-image="CLIENT_LOGO"></div>'
+        self.project.save(update_fields=["extra_fields"])
+
+        uri = reverse(
+            "rolodex:project_extra_field_richtext",
+            kwargs={
+                "pk": self.project.pk,
+                "extra_field_name": self.richtext_extra_field.internal_name,
+            },
+        )
+        response = self.client_mgr.get(uri)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertNotIn("__GW_IMAGE_PREVIEW_", content)
+        if self.project.client.logo:
+            self.assertIn("<img", content)
+            self.assertIn("client_logo_download", content)
 
     def test_project_assignments_render_in_role_order(self):
         lead_role = ProjectRoleFactory(project_role="Lead", position=1)

--- a/ghostwriter/rolodex/urls.py
+++ b/ghostwriter/rolodex/urls.py
@@ -181,6 +181,7 @@ urlpatterns += [
         views.ClientExtraFieldJson.as_view(),
         name="client_extra_field_json",
     ),
+
     path(
         "clients/notes/create/<int:pk>",
         views.ClientNoteCreate.as_view(),
@@ -246,5 +247,10 @@ urlpatterns += [
         "projects/<int:pk>/extra-field-json/<str:extra_field_name>",
         views.ProjectExtraFieldJson.as_view(),
         name="project_extra_field_json",
+    ),
+    path(
+        "projects/<int:pk>/extra-field-richtext/<str:extra_field_name>",
+        views.ProjectExtraFieldRichTextPreview.as_view(),
+        name="project_extra_field_richtext",
     ),
 ]

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -44,7 +44,8 @@ from ghostwriter.api.utils import (
     verify_user_is_privileged,
 )
 from ghostwriter.commandcenter.models import BloodHoundConfiguration, ExtraFieldSpec, ReportConfiguration
-from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldJsonView
+from ghostwriter.commandcenter.views import CollabModelUpdate, ExtraFieldJsonView, ExtraFieldRichTextPreviewView
+
 from ghostwriter.modules import codenames
 from ghostwriter.modules.model_utils import to_dict
 from ghostwriter.modules.reportwriter.base import ReportExportTemplateError
@@ -1731,6 +1732,24 @@ class ProjectDetailView(RoleBasedAccessControlMixin, DetailView):
 
 class ProjectExtraFieldJson(ExtraFieldJsonView):
     model = Project
+
+
+class ProjectExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
+    model = Project
+
+    def build_exporter(self, obj):
+        from ghostwriter.modules.reportwriter.project.json import ExportProjectJson
+
+        return ExportProjectJson(obj)
+
+    def extract_rendered_field(self, exporter, base_context, field_name):
+        value = base_context.get("project", {}).get("extra_fields", {}).get(field_name)
+        if value is None:
+            return ""
+        return str(value.__html__()) if hasattr(value, "__html__") else str(value)
+
+    def get_client(self, obj):
+        return obj.client
 
 
 class ProjectCreate(RoleBasedAccessControlMixin, CreateView):

--- a/ghostwriter/rolodex/views.py
+++ b/ghostwriter/rolodex/views.py
@@ -1738,8 +1738,6 @@ class ProjectExtraFieldRichTextPreview(ExtraFieldRichTextPreviewView):
     model = Project
 
     def build_exporter(self, obj):
-        from ghostwriter.modules.reportwriter.project.json import ExportProjectJson
-
         return ExportProjectJson(obj)
 
     def extract_rendered_field(self, exporter, base_context, field_name):

--- a/ghostwriter/shepherd/templates/shepherd/domain_detail.html
+++ b/ghostwriter/shepherd/templates/shepherd/domain_detail.html
@@ -335,6 +335,8 @@
           <h4>Extra Fields</h4>
           <hr/>
 
+          <p class="text-muted small">Jinja2 template syntax will not be rendered in these previews because a project and report context is needed. Rich text previews with rendered Jinja2 are available on report and project detail pages where these fields are referenced.</p>
+
           <div class="extra-fields-grid">
             {% for field_spec in domain_extra_fields_spec %}
               <section class="extra-field-card">

--- a/ghostwriter/shepherd/templates/shepherd/domain_detail.html
+++ b/ghostwriter/shepherd/templates/shepherd/domain_detail.html
@@ -346,6 +346,7 @@
                     {{ field_spec.get_type_display }} Field
                   {% endif %}
                 </div>
+                <div class="extra-field-type">Loop and reference as <code>object.extra_fields.{{ field_spec.internal_name }}</code></div>
                 <div class="extra-field-value">
                   {% if field_spec.type == "rich_text" %}
                     <span class="extra-field-summary">Use Preview to view formatted content.</span>

--- a/ghostwriter/shepherd/templates/shepherd/server_detail.html
+++ b/ghostwriter/shepherd/templates/shepherd/server_detail.html
@@ -189,52 +189,6 @@
         {% endif %}
       </div>
 
-      {% comment %} Extra Fields Tab {% endcomment %}
-      {% if server_extra_fields_spec %}
-        <div id="extra-fields" class="tab-pane">
-          <h4>Extra Fields</h4>
-          <hr/>
-
-          <div class="extra-fields-grid">
-            {% for field_spec in server_extra_fields_spec %}
-              <section class="extra-field-card">
-                <h5 class="extra-field-name">{{ field_spec.display_name }}</h5>
-                <div class="extra-field-type">
-                  {% if field_spec.type == "rich_text" %}
-                    Rich Text Field
-                  {% else %}
-                    {{ field_spec.get_type_display }} Field
-                  {% endif %}
-                </div>
-                <div class="extra-field-value">
-                  {% if field_spec.type == "rich_text" %}
-                    <span class="extra-field-summary">Use Preview to view formatted content.</span>
-                  {% elif field_spec.type == "json" %}
-                    <span class="extra-field-summary">Use View JSON to inspect structured content.</span>
-                  {% else %}
-                    {% include "user_extra_fields/field.html" with extra_fields=staticserver.extra_fields field_spec=field_spec preview_report=False %}
-                  {% endif %}
-                </div>
-                <div class="extra-field-actions">
-                  {% if field_spec.type == "rich_text" %}
-                    <button type="button" class="btn btn-primary btn-sm icon view-icon" data-toggle="modal"
-                            data-target="#field_spec_{{ field_spec.internal_name }}">Preview
-                    </button>
-                  {% elif field_spec.type == "json" %}
-                    <button type="button" class="btn btn-primary btn-sm icon code-icon" data-toggle="modal"
-                            data-target="#field_spec_{{ field_spec.internal_name }}">View JSON
-                    </button>
-                  {% endif %}
-                  <a class="btn btn-outline-primary btn-sm icon edit-icon"
-                     href="{% url 'shepherd:server_update' staticserver.id %}#extra-fields"
-                     title="Edit {{ field_spec.display_name }}">Edit</a>
-                </div>
-              </section>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
-
       <!-- Notes Tab -->
       <div id="notes" class="tab-pane">
         <h4>Server Notes</h4>
@@ -276,6 +230,53 @@
           <div class="alert alert-warning offset-md-2 col-md-8 mt-1" role="alert">There are no notes for this server.</div>
         {% endif %}
       </div>
+
+      {% comment %} Extra Fields Tab {% endcomment %}
+      {% if server_extra_fields_spec %}
+        <div id="extra-fields" class="tab-pane">
+          <h4>Extra Fields</h4>
+          <hr/>
+
+          <div class="extra-fields-grid">
+            {% for field_spec in server_extra_fields_spec %}
+              <section class="extra-field-card">
+                <h5 class="extra-field-name">{{ field_spec.display_name }}</h5>
+                <div class="extra-field-type">
+                  {% if field_spec.type == "rich_text" %}
+                    Rich Text Field
+                  {% else %}
+                    {{ field_spec.get_type_display }} Field
+                  {% endif %}
+                </div>
+                <div class="extra-field-type">Loop and reference as <code>object.extra_fields.{{ field_spec.internal_name }}</code></div>
+                <div class="extra-field-value">
+                  {% if field_spec.type == "rich_text" %}
+                    <span class="extra-field-summary">Use Preview to view formatted content.</span>
+                  {% elif field_spec.type == "json" %}
+                    <span class="extra-field-summary">Use View JSON to inspect structured content.</span>
+                  {% else %}
+                    {% include "user_extra_fields/field.html" with extra_fields=staticserver.extra_fields field_spec=field_spec preview_report=False %}
+                  {% endif %}
+                </div>
+                <div class="extra-field-actions">
+                  {% if field_spec.type == "rich_text" %}
+                    <button type="button" class="btn btn-primary btn-sm icon view-icon" data-toggle="modal"
+                            data-target="#field_spec_{{ field_spec.internal_name }}">Preview
+                    </button>
+                  {% elif field_spec.type == "json" %}
+                    <button type="button" class="btn btn-primary btn-sm icon code-icon" data-toggle="modal"
+                            data-target="#field_spec_{{ field_spec.internal_name }}">View JSON
+                    </button>
+                  {% endif %}
+                  <a class="btn btn-outline-primary btn-sm icon edit-icon"
+                     href="{% url 'shepherd:server_update' staticserver.id %}#extra-fields"
+                     title="Edit {{ field_spec.display_name }}">Edit</a>
+                </div>
+              </section>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/ghostwriter/shepherd/templates/shepherd/server_detail.html
+++ b/ghostwriter/shepherd/templates/shepherd/server_detail.html
@@ -237,6 +237,8 @@
           <h4>Extra Fields</h4>
           <hr/>
 
+          <p class="text-muted small">Jinja2 template syntax will not be rendered in these previews because a project and report context is needed. Rich text previews with rendered Jinja2 are available on report and project detail pages where these fields are referenced.</p>
+
           <div class="extra-fields-grid">
             {% for field_spec in server_extra_fields_spec %}
               <section class="extra-field-card">

--- a/ghostwriter/shepherd/templates/snippets/domain_nav_tabs.html
+++ b/ghostwriter/shepherd/templates/snippets/domain_nav_tabs.html
@@ -28,6 +28,12 @@
         <span class="badge badge-pill badge-light">{{ domain.history_set.all.count }}</span>
     </a>
 </li>
+<li class="nav-item">
+    <a class="nav-link icon comment-icon" data-toggle="tab" href="#notes">
+        Notes
+        <span class="badge badge-pill badge-light">{{ domain.domainnote_set.all.count }}</span>
+    </a>
+</li>
 {% if domain_extra_fields_spec %}
     <li class="nav-item">
         <a id="id_extra-fields" class="nav-link icon custom-field-icon" data-toggle="tab" href="#extra-fields">
@@ -35,9 +41,3 @@
         </a>
     </li>
 {% endif %}
-<li class="nav-item">
-    <a class="nav-link icon comment-icon" data-toggle="tab" href="#notes">
-        Notes
-        <span class="badge badge-pill badge-light">{{ domain.domainnote_set.all.count }}</span>
-    </a>
-</li>

--- a/ghostwriter/shepherd/templates/snippets/server_nav_tabs.html
+++ b/ghostwriter/shepherd/templates/snippets/server_nav_tabs.html
@@ -11,6 +11,12 @@
         <span class="badge badge-pill badge-light">{{ staticserver.serverhistory_set.all.count }}</span>
     </a>
 </li>
+<li class="nav-item">
+    <a class="nav-link icon comment-icon" data-toggle="tab" href="#notes">
+        Notes
+        <span class="badge badge-pill badge-light">{{ staticserver.servernote_set.all.count }}</span>
+    </a>
+</li>
 {% if server_extra_fields_spec %}
     <li class="nav-item">
         <a id="id_extra-fields" class="nav-link tab-icon custom-field-icon" data-toggle="tab" href="#extra-fields">
@@ -18,9 +24,3 @@
         </a>
     </li>
 {% endif %}
-<li class="nav-item">
-    <a class="nav-link icon comment-icon" data-toggle="tab" href="#notes">
-        Notes
-        <span class="badge badge-pill badge-light">{{ staticserver.servernote_set.all.count }}</span>
-    </a>
-</li>

--- a/ghostwriter/static/css/styles.css
+++ b/ghostwriter/static/css/styles.css
@@ -1307,10 +1307,12 @@ th.severity-header {
   padding-top: 10px;
   padding-bottom: 10px;
   border-bottom: none;
+  border-top: none;
   padding-left: 18px;
   pointer-events: none;
   opacity: 0.75;
   color: #fff;
+  border-radius: 0 !important;
 }
 
 th.severity-header.severity_1 {


### PR DESCRIPTION
# CHANGELOG

## [Unreleased]

### Added

* Added jinja2 rendering to field preview modals for finding, observation, report, and project fields
  * Continuing preview enhancements from v7.2.0, previews now render Jinja2 templating using the report context
  * Clicking the _Preview_ buttons will now trigger the modal and a _Rendering rich text preview..._ loading message
  * It will take a moment to generate the context and render any Jinja2
  * If there are syntax errors, rendering will fail and there will be an error message

### Changed

* Preview modals for rich-text fields now render references, captions, and client logo objects
  * References will be represented by your figure label and a placeholder—e.g., `Figure #`
  * Captions will also use the configured caption label and prefix