### PR TITLE
Changed container start up conditions

### DIFF
--- a/gw-cli.yml
+++ b/gw-cli.yml
@@ -150,7 +150,7 @@ services:
       postgres:
         condition: service_healthy
       django:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
     volumes:
       - ./ssl:/etc/ssl/certs

--- a/gw-cli.yml
+++ b/gw-cli.yml
@@ -64,7 +64,7 @@ services:
       - REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/0
       - WEB_CONCURRENCY=${DJANGO_WEB_CONCURRENCY}
     healthcheck:
-      test: curl --insecure --fail https://nginx/status/simple/ || exit 1
+      test: curl --fail http://django:8000/status/simple/ || exit 1
       interval: ${HEALTHCHECK_INTERVAL}
       timeout: ${HEALTHCHECK_TIMEOUT}
       retries: ${HEALTHCHECK_RETRIES}

--- a/local.yml
+++ b/local.yml
@@ -222,7 +222,7 @@ services:
       postgres:
         condition: service_healthy
       django:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "${HASURA_GRAPHQL_SERVER_PORT}:8080"
       - "9691:9691"

--- a/production.yml
+++ b/production.yml
@@ -71,7 +71,7 @@ services:
         max-file: "3"
         max-size: "10m"
     healthcheck:
-      test: curl --insecure --fail https://nginx/status/simple/ || exit 1
+      test: curl --fail http://django:8000/status/simple/ || exit 1
       interval: ${HEALTHCHECK_INTERVAL}
       timeout: ${HEALTHCHECK_TIMEOUT}
       retries: ${HEALTHCHECK_RETRIES}

--- a/production.yml
+++ b/production.yml
@@ -184,7 +184,7 @@ services:
       postgres:
         condition: service_healthy
       django:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
     volumes:
       - ./ssl:/etc/ssl/certs


### PR DESCRIPTION
A user reported, and I managed to reproduce, a scenario where the collab editor did not work on a fresh install. We wait for Django to start before starting Hasura, but if Django starts slowly and does not finish migrations before Hasura connects to PostgreSQL it will be in a bad state. Restarting the container resolved the issue, so this change to make it wait for Django to complete its start prevents this scenario.