### PR TITLE
Fix collaborative finding save loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed a report finding ordering feedback loop that could generate excessive Hasura events, database writes, and logs after bulk inserts (Closes #924)
+  * Finding positions now converge deterministically under concurrent and out-of-order events without delaying collaborative updates
+  * Long-running collaborative editors renew document-scoped JWTs through the authenticated Django session
+
 ## [7.2.5] - 1 August 2026
 
 ### Changed

--- a/ghostwriter/api/tests/test_views.py
+++ b/ghostwriter/api/tests/test_views.py
@@ -4,16 +4,26 @@ import copy
 import json
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta
 from http import HTTPStatus
+from threading import Barrier
 
 # Django Imports
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.core.files.base import ContentFile
+from django.db import close_old_connections, connection
 from django.http import JsonResponse
-from django.test import Client, RequestFactory, TestCase, override_settings
+from django.test import (
+    Client,
+    RequestFactory,
+    TestCase,
+    TransactionTestCase,
+    override_settings,
+)
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_str
@@ -3190,6 +3200,37 @@ class GraphqlReportFindingEventTests(TestCase):
     def setUp(self):
         self.client = Client()
 
+    def post_change_event(self, operation, old, new):
+        """Deliver a report finding Hasura event to its webhook."""
+        return self.client.post(
+            self.change_uri,
+            content_type="application/json",
+            data={
+                "event": {
+                    "op": operation,
+                    "data": {
+                        "old": old,
+                        "new": new,
+                    },
+                },
+            },
+            **{
+                "HTTP_HASURA_ACTION_SECRET": f"{ACTION_SECRET}",
+            },
+        )
+
+    def assert_contiguous_positions(self, severity):
+        """Assert positions are unique and contiguous for a severity group."""
+        positions = list(
+            self.ReportFindingLink.objects.filter(
+                report=self.report,
+                severity=severity,
+            )
+            .order_by("position", "id")
+            .values_list("position", flat=True)
+        )
+        self.assertEqual(positions, list(range(1, len(positions) + 1)))
+
     def test_model_cleaning_position(self):
         self.ReportFindingLink.objects.all().delete()
         first_finding = ReportFindingLinkFactory(
@@ -3428,6 +3469,234 @@ class GraphqlReportFindingEventTests(TestCase):
         third_finding.refresh_from_db()
         self.assertEqual(first_finding.position, 1)
         self.assertEqual(third_finding.position, 2)
+
+    def test_bulk_insert_events_converge_without_follow_up_writes(self):
+        """Bulk GraphQL inserts must not produce a self-sustaining event storm."""
+        self.ReportFindingLink.objects.all().delete()
+        findings = [
+            ReportFindingLinkFactory(
+                report=self.report,
+                severity=self.critical_severity,
+                position=1,
+            )
+            for _ in range(12)
+        ]
+
+        # Hasura delivers one insert event per row; delivery order is not a
+        # meaningful ordering contract, so deliberately reverse it here.
+        with CaptureQueriesContext(connection) as insert_queries:
+            for finding in reversed(findings):
+                response = self.post_change_event(
+                    "INSERT",
+                    None,
+                    {
+                        "id": finding.id,
+                        "position": 1,
+                        "severity_id": finding.severity_id,
+                    },
+                )
+                self.assertEqual(response.status_code, 200)
+
+        insert_updates = [
+            query
+            for query in insert_queries.captured_queries
+            if 'UPDATE "reporting_reportfindinglink"' in query["sql"]
+        ]
+        self.assertEqual(len(insert_updates), 1)
+
+        self.assert_contiguous_positions(self.critical_severity)
+        positions_before_follow_up = list(
+            self.ReportFindingLink.objects.filter(report=self.report)
+            .order_by("id")
+            .values_list("id", "position")
+        )
+
+        # Every changed position emits an update event. Once normalized, each
+        # follow-up must be a no-op and, critically, must not enqueue another.
+        with CaptureQueriesContext(connection) as queries:
+            for finding in findings:
+                finding.refresh_from_db()
+                response = self.post_change_event(
+                    "UPDATE",
+                    {
+                        "id": finding.id,
+                        "position": 1,
+                        "severity_id": finding.severity_id,
+                    },
+                    {
+                        "id": finding.id,
+                        "position": finding.position,
+                        "severity_id": finding.severity_id,
+                    },
+                )
+                self.assertEqual(response.status_code, 200)
+
+        finding_updates = [
+            query
+            for query in queries.captured_queries
+            if 'UPDATE "reporting_reportfindinglink"' in query["sql"]
+        ]
+        self.assertEqual(finding_updates, [])
+        self.assertEqual(
+            list(
+                self.ReportFindingLink.objects.filter(report=self.report)
+                .order_by("id")
+                .values_list("id", "position")
+            ),
+            positions_before_follow_up,
+        )
+
+    def test_non_ordering_update_event_does_not_touch_database(self):
+        """Content-only updates must not enter the ordering transaction."""
+        finding = ReportFindingLinkFactory(
+            report=self.report,
+            severity=self.critical_severity,
+            position=1,
+        )
+        event_data = {
+            "id": finding.id,
+            "position": finding.position,
+            "severity_id": finding.severity_id,
+        }
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.post_change_event(
+                "UPDATE",
+                event_data,
+                event_data,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        finding_queries = [
+            query
+            for query in queries.captured_queries
+            if "reporting_reportfindinglink" in query["sql"]
+        ]
+        self.assertEqual(finding_queries, [])
+
+    def test_stale_position_event_preserves_newer_order(self):
+        """Out-of-order Hasura events must not replay an older move."""
+        self.ReportFindingLink.objects.all().delete()
+        first_finding = ReportFindingLinkFactory(
+            report=self.report,
+            severity=self.critical_severity,
+            position=1,
+        )
+        second_finding = ReportFindingLinkFactory(
+            report=self.report,
+            severity=self.critical_severity,
+            position=2,
+        )
+        third_finding = ReportFindingLinkFactory(
+            report=self.report,
+            severity=self.critical_severity,
+            position=3,
+        )
+
+        first_finding.position = 3
+        first_finding.save()
+        older_event = {
+            "id": first_finding.id,
+            "position": 3,
+            "severity_id": first_finding.severity_id,
+        }
+        first_finding.position = 2
+        first_finding.save()
+        newer_event = {
+            "id": first_finding.id,
+            "position": 2,
+            "severity_id": first_finding.severity_id,
+        }
+
+        response = self.post_change_event(
+            "UPDATE",
+            older_event,
+            newer_event,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.post_change_event(
+            "UPDATE",
+            {
+                "id": first_finding.id,
+                "position": 1,
+                "severity_id": first_finding.severity_id,
+            },
+            older_event,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        first_finding.refresh_from_db()
+        second_finding.refresh_from_db()
+        third_finding.refresh_from_db()
+        self.assertEqual(first_finding.position, 2)
+        self.assertEqual(second_finding.position, 1)
+        self.assertEqual(third_finding.position, 3)
+        self.assert_contiguous_positions(self.critical_severity)
+
+
+class GraphqlReportFindingConcurrentEventTests(TransactionTestCase):
+    """Concurrency regression coverage for report finding Hasura events."""
+
+    def setUp(self):
+        self.ReportFindingLink = ReportFindingLinkFactory._meta.model
+        self.critical_severity = SeverityFactory(severity="Critical", weight=0)
+        self.report = ReportFactory()
+        self.change_uri = reverse("api:graphql_reportfinding_change_event")
+
+    def test_concurrent_bulk_insert_events_converge(self):
+        """Concurrent insert events must serialize and leave one stable order."""
+        findings = [
+            ReportFindingLinkFactory(
+                report=self.report,
+                severity=self.critical_severity,
+                position=1,
+            )
+            for _ in range(8)
+        ]
+        start = Barrier(len(findings))
+
+        def deliver_event(finding):
+            close_old_connections()
+            try:
+                start.wait()
+                response = Client().post(
+                    self.change_uri,
+                    content_type="application/json",
+                    data={
+                        "event": {
+                            "op": "INSERT",
+                            "data": {
+                                "old": None,
+                                "new": {
+                                    "id": finding.id,
+                                    "position": 1,
+                                    "severity_id": finding.severity_id,
+                                },
+                            },
+                        },
+                    },
+                    **{
+                        "HTTP_HASURA_ACTION_SECRET": f"{ACTION_SECRET}",
+                    },
+                )
+                return response.status_code
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=len(findings)) as executor:
+            statuses = list(executor.map(deliver_event, findings))
+
+        self.assertEqual(statuses, [200] * len(findings))
+        positions = list(
+            self.ReportFindingLink.objects.filter(
+                report=self.report,
+                severity=self.critical_severity,
+            )
+            .order_by("position", "id")
+            .values_list("position", flat=True)
+        )
+        self.assertEqual(positions, list(range(1, len(findings) + 1)))
 
 
 class GraphqlProjectContactUpdateEventTests(TestCase):
@@ -5330,6 +5599,11 @@ class CheckEditPermissionsTests(TestCase):
             data=self.data(),
         )
         self.assertEquals(response.status_code, 200, response.content)
+        self.assertEqual(
+            {key: response.json()[key] for key in ("username", "userId")},
+            {"username": self.manager.username, "userId": self.manager.id},
+        )
+        self.assertGreater(response.json()["expiresAt"], timezone.now().timestamp())
 
     def test_access_project_allowed_with_matching_collab_scope(self):
         response = self.client.post(
@@ -5425,6 +5699,24 @@ class CheckEditPermissionsTests(TestCase):
         )
         self.assertEqual(response.status_code, 401, response.content)
 
+    def test_rejects_api_token(self):
+        _, token = APIKey.objects.create_token(
+            user=self.manager,
+            name="Collab API Token",
+        )
+
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers={
+                "Hasura-Action-Secret": ACTION_SECRET,
+                "Authorization": f"Bearer {token}",
+            },
+            data=self.data(),
+        )
+
+        self.assertEqual(response.status_code, 401, response.content)
+
     def test_rejects_expired_collab_jwt(self):
         response = self.client.post(
             self.uri,
@@ -5467,6 +5759,122 @@ class CheckEditPermissionsTests(TestCase):
         self.assertEquals(response.status_code, 404, response.content)
 
 
+class CollabTokenRefreshTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.finding = FindingFactory()
+        cls.project = ProjectFactory()
+        cls.report_finding = ReportFindingLinkFactory()
+        cls.user = UserFactory(password=PASSWORD)
+        cls.manager = UserFactory(password=PASSWORD, role="manager")
+        cls.uri = reverse("api:collab_token_refresh")
+
+    def setUp(self):
+        self.client = Client()
+
+    def post(self, *, model="finding", object_id=None, client=None, **headers):
+        return (client or self.client).post(
+            self.uri,
+            content_type="application/json",
+            data={
+                "model": model,
+                "id": object_id if object_id is not None else self.finding.id,
+            },
+            **headers,
+        )
+
+    def test_requires_authenticated_session(self):
+        response = self.post()
+
+        self.assertEqual(response.status_code, 401, response.content)
+
+    def test_does_not_accept_collab_jwt_without_session(self):
+        _, token = utils.generate_jwt(
+            self.manager,
+            token_type=utils.COLLAB_JWT_TYPE,
+            extra_claims=utils.collab_jwt_claims("finding", self.finding),
+        )
+
+        response = self.post(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        self.assertEqual(response.status_code, 401, response.content)
+
+    def test_requires_csrf_token(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.manager)
+
+        response = self.post(client=csrf_client)
+
+        self.assertEqual(response.status_code, 403, response.content)
+
+    def test_renews_exact_document_scope_for_editable_object(self):
+        self.client.force_login(self.manager)
+
+        response = self.post(
+            model="report_finding_link",
+            object_id=self.report_finding.id,
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        payload = utils.get_jwt_payload(response.json()["token"])
+        self.assertEqual(
+            utils.get_jwt_type(response.json()["token"]), utils.COLLAB_JWT_TYPE
+        )
+        self.assertEqual(payload[utils.COLLAB_MODEL_CLAIM], "report_finding_link")
+        self.assertEqual(
+            payload[utils.COLLAB_OBJECT_ID_CLAIM],
+            self.report_finding.id,
+        )
+        self.assertEqual(
+            payload[utils.COLLAB_REPORT_ID_CLAIM],
+            self.report_finding.report_id,
+        )
+        self.assertEqual(
+            payload[utils.COLLAB_FINDING_ID_CLAIM],
+            self.report_finding.id,
+        )
+        self.assertEqual(response.json()["expiresAt"], payload["exp"])
+        self.assertLessEqual(
+            payload["exp"],
+            int((timezone.now() + utils.COLLAB_JWT_EXPIRATION_DELTA).timestamp()),
+        )
+        self.assertGreater(
+            payload["exp"],
+            int(timezone.now().timestamp()),
+        )
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
+
+    def test_rechecks_permission_on_every_renewal(self):
+        assignment = ProjectAssignmentFactory(
+            project=self.project,
+            operator=self.user,
+        )
+        self.client.force_login(self.user)
+
+        allowed = self.post(model="project", object_id=self.project.id)
+        assignment.delete()
+        denied = self.post(model="project", object_id=self.project.id)
+
+        self.assertEqual(allowed.status_code, 200, allowed.content)
+        self.assertEqual(denied.status_code, 403, denied.content)
+
+    def test_rejects_uneditable_object(self):
+        self.client.force_login(self.user)
+
+        response = self.post()
+
+        self.assertEqual(response.status_code, 403, response.content)
+
+    def test_rejects_unknown_model_and_invalid_id(self):
+        self.client.force_login(self.manager)
+
+        unknown_model = self.post(model="user")
+        invalid_id = self.post(object_id=0)
+
+        self.assertEqual(unknown_model.status_code, 400, unknown_model.content)
+        self.assertEqual(invalid_id.status_code, 400, invalid_id.content)
+
+
 class GetTagsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -5488,6 +5896,22 @@ class GetTagsTest(TestCase):
             _, token = generate_user_jwt(user)
             headers["Authorization"] = f"Bearer {token}"
         return headers
+
+    def collab_headers(self, model=None, object_id=None):
+        model = model or "report_finding_link"
+        object_id = object_id or self.report_finding.id
+        _, token = utils.generate_jwt(
+            self.manager,
+            token_type=utils.COLLAB_JWT_TYPE,
+            extra_claims={
+                utils.COLLAB_MODEL_CLAIM: model,
+                utils.COLLAB_OBJECT_ID_CLAIM: object_id,
+            },
+        )
+        return {
+            "Hasura-Action-Secret": ACTION_SECRET,
+            "Authorization": f"Bearer {token}",
+        }
 
     def data(self, hasura_role="user", model=None, object_id=None):
         return {
@@ -5531,6 +5955,29 @@ class GetTagsTest(TestCase):
         self.assertEquals(response.status_code, 200)
         body = response.json()
         self.assertEqual(set(body["tags"]), self.tags)
+
+    def test_get_report_finding_tags_allowed_scoped_collab_token(self):
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.collab_headers(),
+            data=self.data(),
+        )
+
+        self.assertEquals(response.status_code, 200, response.content)
+        self.assertEqual(set(response.json()["tags"]), self.tags)
+
+    def test_get_report_finding_tags_rejects_collab_token_for_another_object(self):
+        other_finding = ReportFindingLinkFactory(report=self.report_finding.report)
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.collab_headers(object_id=other_finding.id),
+            data=self.data(),
+        )
+
+        self.assertEquals(response.status_code, 403, response.content)
+        self.assertNotIn("tags", response.json())
 
     def test_get_report_finding_tags_rejects_forged_admin_without_token(self):
         response = self.client.post(
@@ -5668,6 +6115,22 @@ class SetTagsTest(TestCase):
             headers["Authorization"] = f"Bearer {token}"
         return headers
 
+    def collab_headers(self, model=None, object_id=None):
+        model = model or "report_finding_link"
+        object_id = object_id or self.report_finding.id
+        _, token = utils.generate_jwt(
+            self.manager,
+            token_type=utils.COLLAB_JWT_TYPE,
+            extra_claims={
+                utils.COLLAB_MODEL_CLAIM: model,
+                utils.COLLAB_OBJECT_ID_CLAIM: object_id,
+            },
+        )
+        return {
+            "Hasura-Action-Secret": ACTION_SECRET,
+            "Authorization": f"Bearer {token}",
+        }
+
     def data(self, tags, hasura_role="user", model=None, object_id=None):
         v = {
             "input": {
@@ -5691,6 +6154,31 @@ class SetTagsTest(TestCase):
         self.assertEqual(
             set(self.report_finding.tags.names()), self.tags, response.content
         )
+
+    def test_set_report_finding_tags_allowed_scoped_collab_token(self):
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.collab_headers(),
+            data=self.data(self.tags),
+        )
+
+        self.assertEquals(response.status_code, 200, response.content)
+        self.report_finding.refresh_from_db()
+        self.assertEqual(set(self.report_finding.tags.names()), self.tags)
+
+    def test_set_report_finding_tags_rejects_collab_token_for_another_object(self):
+        other_finding = ReportFindingLinkFactory(report=self.report_finding.report)
+        response = self.client.post(
+            self.uri,
+            content_type="application/json",
+            headers=self.collab_headers(object_id=other_finding.id),
+            data=self.data(self.tags),
+        )
+
+        self.assertEquals(response.status_code, 403, response.content)
+        self.report_finding.refresh_from_db()
+        self.assertEqual(set(self.report_finding.tags.names()), set())
 
     def test_set_report_finding_tags_not_allowed(self):
         response = self.client.post(

--- a/ghostwriter/api/urls.py
+++ b/ghostwriter/api/urls.py
@@ -48,6 +48,7 @@ from ghostwriter.api.views import (
     GraphqlUploadOplogRecording,
     GraphqlDownloadRecording,
     CheckEditPermissions,
+    CollabTokenRefresh,
     GetTags,
     ObjectsByTag,
     SetTags,
@@ -158,6 +159,11 @@ urlpatterns = [
         "check_permissions",
         csrf_exempt(CheckEditPermissions.as_view()),
         name="check_permissions"
+    ),
+    path(
+        "collab/token/refresh",
+        CollabTokenRefresh.as_view(),
+        name="collab_token_refresh",
     ),
     path("tags/get", csrf_exempt(GetTags.as_view()), name="graphql_get_tags"),
     path("tags/set", csrf_exempt(SetTags.as_view()), name="graphql_set_tags"),

--- a/ghostwriter/api/utils.py
+++ b/ghostwriter/api/utils.py
@@ -1,6 +1,6 @@
 # Standard Libraries
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 # Django Imports
@@ -35,6 +35,40 @@ COLLAB_MODEL_CLAIM = "gw_collab_model"
 COLLAB_OBJECT_ID_CLAIM = "gw_collab_object_id"
 COLLAB_REPORT_ID_CLAIM = "gw_collab_report_id"
 COLLAB_FINDING_ID_CLAIM = "gw_collab_finding_id"
+COLLAB_JWT_EXPIRATION_DELTA = timedelta(hours=24)
+
+
+def collab_jwt_claims(model_name, obj):
+    """Return the document scope embedded in a collaboration JWT."""
+    report_id = COLLAB_NO_ID
+    finding_id = COLLAB_NO_ID
+
+    if model_name == "report":
+        report_id = obj.pk
+    elif model_name == "report_finding_link":
+        report_id = obj.report_id or COLLAB_NO_ID
+        finding_id = obj.pk
+    elif model_name == "report_observation_link":
+        report_id = obj.report_id or COLLAB_NO_ID
+
+    return {
+        COLLAB_MODEL_CLAIM: model_name,
+        COLLAB_OBJECT_ID_CLAIM: obj.pk,
+        COLLAB_REPORT_ID_CLAIM: report_id,
+        COLLAB_FINDING_ID_CLAIM: finding_id,
+    }
+
+
+def generate_collab_jwt(user, model_name, obj):
+    """Generate a short-lived JWT scoped to one collaborative document."""
+    expires_at = datetime.now(timezone.utc) + COLLAB_JWT_EXPIRATION_DELTA
+    _, token = generate_jwt(
+        user,
+        exp=expires_at,
+        token_type=COLLAB_JWT_TYPE,
+        extra_claims=collab_jwt_claims(model_name, obj),
+    )
+    return int(expires_at.timestamp()), token
 
 
 def get_jwt_type(token):

--- a/ghostwriter/api/views.py
+++ b/ghostwriter/api/views.py
@@ -55,7 +55,11 @@ from ghostwriter.api.models import (
 )
 from ghostwriter.commandcenter.models import ExtraFieldModel, GeneralConfiguration
 from ghostwriter.modules import codenames
-from ghostwriter.modules.model_utils import set_finding_positions, to_dict
+from ghostwriter.modules.model_utils import (
+    normalize_finding_positions,
+    set_finding_positions,
+    to_dict,
+)
 from ghostwriter.modules.passive_voice.detector import get_detector
 from ghostwriter.modules.reportwriter import jinja_string_literal
 from ghostwriter.modules.reportwriter.report.json import ExportReportJson
@@ -98,6 +102,15 @@ SERVICE_TOKEN_ANY_PROJECT_READ_REQUIREMENT = {
     "resource_type": ServiceTokenPermission.ResourceType.PROJECT,
     "action": ServiceTokenPermission.Action.READ,
     "scope": SERVICE_TOKEN_SCOPE_ANY,
+}
+COLLAB_EDIT_MODELS = {
+    # Models here need to have a ``user_can_edit(user)`` method.
+    "observation": Observation,
+    "report_observation_link": ReportObservationLink,
+    "finding": Finding,
+    "report_finding_link": ReportFindingLink,
+    "report": Report,
+    "project": Project,
 }
 
 
@@ -1824,6 +1837,13 @@ class GraphqlReportFindingChangeEvent(HasuraEventView):
     """
 
     def post(self, request, *args, **kwargs):
+        if (
+            self.event["op"] == "UPDATE"
+            and self.old_data["position"] == self.new_data["position"]
+            and self.old_data["severity_id"] == self.new_data["severity_id"]
+        ):
+            return JsonResponse(self.data, status=self.status)
+
         instance = ReportFindingLink.objects.get(id=self.new_data["id"])
 
         if self.event["op"] == "INSERT":
@@ -1855,16 +1875,11 @@ class GraphqlReportFindingDeleteEvent(HasuraEventView):
 
     def post(self, request, *args, **kwargs):
         try:
-            findings_queryset = ReportFindingLink.objects.filter(
-                Q(report=self.old_data["report_id"])
-                & Q(severity=self.old_data["severity_id"])
+            normalize_finding_positions(
+                ReportFindingLink,
+                self.old_data["report_id"],
+                self.old_data["severity_id"],
             )
-            if findings_queryset:
-                counter = 1
-                for finding in findings_queryset:
-                    # Adjust position to close gap created by the removed finding
-                    findings_queryset.filter(id=finding.id).update(position=counter)
-                    counter += 1
         except Report.DoesNotExist:  # pragma: no cover
             # Report was deleted, so no need to adjust positions
             pass
@@ -2628,9 +2643,57 @@ class ServiceTokenCreate(utils.RoleBasedAccessControlMixin, FormView):
         return super().form_valid(form)
 
 
+class CollabTokenRefresh(View):
+    """Renew one document-scoped collaboration JWT using the Django session."""
+
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        if not request.user.is_authenticated or not request.user.is_active:
+            return JsonResponse({"error": "Authentication required"}, status=401)
+
+        try:
+            data = json.loads(request.body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return JsonResponse({"error": "Invalid request body"}, status=400)
+
+        if not isinstance(data, dict) or not isinstance(data.get("model"), str):
+            return JsonResponse({"error": "Invalid request body"}, status=400)
+
+        model_name = data["model"].lower()
+        cls = COLLAB_EDIT_MODELS.get(model_name)
+        raw_object_id = data.get("id")
+        if isinstance(raw_object_id, bool):
+            return JsonResponse({"error": "Invalid request body"}, status=400)
+        try:
+            object_id = int(raw_object_id)
+        except (TypeError, ValueError):
+            return JsonResponse({"error": "Invalid request body"}, status=400)
+
+        if cls is None or object_id < 1:
+            return JsonResponse({"error": "Invalid request body"}, status=400)
+
+        try:
+            obj = cls.objects.get(id=object_id)
+        except ObjectDoesNotExist:
+            return JsonResponse({"error": "Not found"}, status=404)
+
+        if not obj.user_can_edit(request.user):
+            return JsonResponse({"error": "Permission denied"}, status=403)
+
+        expires_at, token = utils.generate_collab_jwt(
+            request.user,
+            model_name,
+            obj,
+        )
+        response = JsonResponse({"token": token, "expiresAt": expires_at})
+        response["Cache-Control"] = "no-store"
+        return response
+
+
 class CheckEditPermissions(JwtRequiredMixin, HasuraActionView):
     """
-    Checks if the given API token or JWT authorizes edit accesses to an object.
+    Checks if a document-scoped JWT authorizes edit access to an object.
 
     Used by the collab editing server for authentication. Not used by Hasura.
     """
@@ -2638,15 +2701,15 @@ class CheckEditPermissions(JwtRequiredMixin, HasuraActionView):
     allow_login_jwt = False
     allow_collab_jwt = True
     required_inputs = ["model", "id"]
-    available_models = {
-        # Models here need to have a `user_can_edit(user)` method.
-        "observation": Observation,
-        "report_observation_link": ReportObservationLink,
-        "finding": Finding,
-        "report_finding_link": ReportFindingLink,
-        "report": Report,
-        "project": Project,
-    }
+    available_models = COLLAB_EDIT_MODELS
+
+    def post_authentication(self, request, *args, **kwargs):
+        response = super().post_authentication(request, *args, **kwargs)
+        if response is not None:
+            return response
+        if self.jwt_token_type != utils.COLLAB_JWT_TYPE:
+            return self.invalid_token_response()
+        return None
 
     def get_collab_object_scope_id(self) -> int:
         if not self.jwt_payload:
@@ -2704,7 +2767,18 @@ class CheckEditPermissions(JwtRequiredMixin, HasuraActionView):
                 ),
                 status=403,
             )
-        return JsonResponse(self.user_obj.username, status=200, safe=False)
+        expires_at = self.jwt_payload.get("exp")
+        if not isinstance(expires_at, (int, float)):
+            return self.invalid_token_response()
+
+        return JsonResponse(
+            {
+                "username": self.user_obj.username,
+                "userId": self.user_obj.id,
+                "expiresAt": int(expires_at),
+            },
+            status=200,
+        )
 
 
 class ServiceTokenTagAccessMixin:
@@ -2783,7 +2857,46 @@ class ServiceTokenTagAccessMixin:
         return cls.objects.none()
 
 
-class GetTags(ServiceTokenTagAccessMixin, JwtRequiredMixin, HasuraActionView):
+class CollabTokenScopeMixin:
+    """Restrict collaboration JWTs to the document they were issued for."""
+
+    allow_collab_jwt = True
+
+    def post_authentication(self, request, *args, **kwargs):
+        response = super().post_authentication(request, *args, **kwargs)
+        if response is not None or self.jwt_token_type != utils.COLLAB_JWT_TYPE:
+            return response
+
+        expected_model = self.jwt_payload.get(utils.COLLAB_MODEL_CLAIM)
+        expected_object_id = self.jwt_payload.get(utils.COLLAB_OBJECT_ID_CLAIM)
+        requested_model = str(self.input.get("model", "")).lower()
+        requested_object_id = self.input.get("id")
+        if requested_model == expected_model and str(requested_object_id) == str(
+            expected_object_id
+        ):
+            return None
+
+        logger.warning(
+            "Rejected collab token for %s %s; token is scoped to %s %s",
+            requested_model,
+            requested_object_id,
+            expected_model,
+            expected_object_id,
+        )
+        return JsonResponse(
+            utils.generate_hasura_error_payload(
+                "Collaboration token is not authorized for this object", "Unauthorized"
+            ),
+            status=HTTPStatus.FORBIDDEN,
+        )
+
+
+class GetTags(
+    CollabTokenScopeMixin,
+    ServiceTokenTagAccessMixin,
+    JwtRequiredMixin,
+    HasuraActionView,
+):
     required_inputs = ["model", "id"]
     available_models = {
         # Models here need to have a `tags` field, and optionally a `user_can_view(user)` method.
@@ -2834,7 +2947,12 @@ class GetTags(ServiceTokenTagAccessMixin, JwtRequiredMixin, HasuraActionView):
         return JsonResponse({"tags": list(obj.tags.names())})
 
 
-class SetTags(ServiceTokenTagAccessMixin, JwtRequiredMixin, HasuraActionView):
+class SetTags(
+    CollabTokenScopeMixin,
+    ServiceTokenTagAccessMixin,
+    JwtRequiredMixin,
+    HasuraActionView,
+):
     service_token_tag_action = ServiceTokenPermission.Action.UPDATE
     required_inputs = ["model", "id", "tags"]
     available_models = {

--- a/ghostwriter/commandcenter/templates/collab_editing/attrs_snippet.html
+++ b/ghostwriter/commandcenter/templates/collab_editing/attrs_snippet.html
@@ -1,10 +1,12 @@
 {% load static %}
 
-<meta name="csrf-token" content="{{ csrf_token }}">
+<meta id="csrf-token" name="csrf-token" content="{{ csrf_token }}">
 <script type="text/plain" id="yjs-url">/ws-collab</script>
+<script type="text/plain" id="yjs-model">{{collab_model_name}}</script>
 <script type="text/plain" id="yjs-object-id">{{collab_model_id}}</script>
 <script type="text/plain" id="yjs-username">{{collab_user.get_username}}</script>
 <script type="text/plain" id="yjs-jwt">{{collab_jwt}}</script>
+<script type="text/plain" id="collab-token-refresh-url">{% url 'api:collab_token_refresh' %}</script>
 <script type="text/plain" id="default-cvss-version">{{collab_default_cvss_version}}</script>
 
 {% if collab_extra_fields_spec_ser is not None %}
@@ -12,6 +14,5 @@
 {% endif %}
 
 <script type="text/plain" id="graphql-path">/v1/graphql</script>
-<script type="text/plain" id="graphql-auth">{{collab_jwt}}</script>
 
 <link rel="stylesheet" href="{% static 'assets/collab_common.css' %}">

--- a/ghostwriter/commandcenter/tests/test_views.py
+++ b/ghostwriter/commandcenter/tests/test_views.py
@@ -28,6 +28,7 @@ class CollabModelUpdateTests(TestCase):
         self.assertEqual(
             utils.get_jwt_type(context["collab_jwt"]), utils.COLLAB_JWT_TYPE
         )
+        self.assertEqual(context["collab_model_name"], "")
 
     def test_context_data_includes_collab_scope_claims(self):
         user = UserFactory()
@@ -43,6 +44,7 @@ class CollabModelUpdateTests(TestCase):
         )
         payload = utils.get_jwt_payload(context["collab_jwt"])
 
+        self.assertEqual(context["collab_model_name"], "report_finding_link")
         self.assertEqual(payload[utils.COLLAB_MODEL_CLAIM], "report_finding_link")
         self.assertEqual(payload[utils.COLLAB_OBJECT_ID_CLAIM], report_finding.id)
         self.assertEqual(

--- a/ghostwriter/commandcenter/views.py
+++ b/ghostwriter/commandcenter/views.py
@@ -1,7 +1,7 @@
 
 import logging
 from typing import Any
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 
 from django.views import View
 from django.views.generic.detail import DetailView, SingleObjectMixin
@@ -17,11 +17,13 @@ from django.views.decorators.csrf import requires_csrf_token
 from ghostwriter.api.utils import (
     COLLAB_FINDING_ID_CLAIM,
     COLLAB_JWT_TYPE,
+    COLLAB_JWT_EXPIRATION_DELTA,
     COLLAB_MODEL_CLAIM,
     COLLAB_NO_ID,
     COLLAB_OBJECT_ID_CLAIM,
     COLLAB_REPORT_ID_CLAIM,
     RoleBasedAccessControlMixin,
+    collab_jwt_claims,
     generate_jwt,
 )
 from ghostwriter.commandcenter.models import ExtraFieldSpec, ReportConfiguration
@@ -78,23 +80,7 @@ class CollabModelUpdate(RoleBasedAccessControlMixin, DetailView):
 
     @staticmethod
     def collab_jwt_claims(model_name, obj):
-        report_id = COLLAB_NO_ID
-        finding_id = COLLAB_NO_ID
-
-        if model_name == "report":
-            report_id = obj.pk
-        elif model_name == "report_finding_link":
-            report_id = obj.report_id or COLLAB_NO_ID
-            finding_id = obj.pk
-        elif model_name == "report_observation_link":
-            report_id = obj.report_id or COLLAB_NO_ID
-
-        return {
-            COLLAB_MODEL_CLAIM: model_name,
-            COLLAB_OBJECT_ID_CLAIM: obj.pk,
-            COLLAB_REPORT_ID_CLAIM: report_id,
-            COLLAB_FINDING_ID_CLAIM: finding_id,
-        }
+        return collab_jwt_claims(model_name, obj)
 
     @staticmethod
     def context_data(user, obj_id, extra_fields=None, collab_claims=None):
@@ -112,10 +98,11 @@ class CollabModelUpdate(RoleBasedAccessControlMixin, DetailView):
             "collab_user": user,
             "collab_jwt": generate_jwt(
                 user,
-                exp=datetime.now(timezone.utc) + timedelta(hours=24),
+                exp=datetime.now(timezone.utc) + COLLAB_JWT_EXPIRATION_DELTA,
                 token_type=COLLAB_JWT_TYPE,
                 extra_claims=collab_claims,
             )[1],
+            "collab_model_name": collab_claims[COLLAB_MODEL_CLAIM],
             "collab_model_id": obj_id,
             "collab_media_url": settings.MEDIA_URL,
             "collab_extra_fields_spec_ser":

--- a/ghostwriter/modules/model_utils.py
+++ b/ghostwriter/modules/model_utils.py
@@ -2,9 +2,11 @@
 
 # Standard Libraries
 from itertools import chain
+from typing import Optional, Type
 
 # Django Imports
 import django
+from django.db import transaction
 from django.db.models import ForeignKey, Q
 
 
@@ -38,15 +40,103 @@ def to_dict(instance: django.db.models.Model, include_id: bool = False, resolve_
     return data
 
 
+def _clamp_position(position: int, count: int) -> int:
+    """Return a one-based position that fits inside a group of findings."""
+    if count < 1:
+        return 1
+    return min(max(position, 1), count)
+
+
+def normalize_finding_positions(
+    model: Type[django.db.models.Model],
+    report_id: int,
+    severity_id: int,
+    moving_instance_id: Optional[int] = None,
+    target_position: Optional[int] = None,
+    skip_if_contiguous: bool = False,
+) -> None:
+    """
+    Normalize the positions for one report and severity group.
+
+    The report row lock serializes all ordering work for that report. The
+    deterministic ``position, id`` order makes duplicate positions converge,
+    while only writing rows whose position must change makes follow-up Hasura
+    events no-ops.
+    """
+    report_model = model._meta.get_field("report").related_model
+    with transaction.atomic():
+        report_model.objects.select_for_update().get(id=report_id)
+        _normalize_locked_finding_positions(
+            model,
+            report_id,
+            severity_id,
+            moving_instance_id,
+            target_position,
+            skip_if_contiguous,
+        )
+
+
+def _normalize_locked_finding_positions(
+    model: Type[django.db.models.Model],
+    report_id: int,
+    severity_id: int,
+    moving_instance_id: Optional[int] = None,
+    target_position: Optional[int] = None,
+    skip_if_contiguous: bool = False,
+) -> None:
+    """Normalize one severity group while the caller holds the report lock."""
+    findings = list(
+        model.objects.select_for_update()
+        .filter(Q(report_id=report_id) & Q(severity_id=severity_id))
+        .order_by("position", "id")
+    )
+    if not findings:
+        return
+
+    if skip_if_contiguous and all(
+        finding.position == position
+        for position, finding in enumerate(findings, start=1)
+    ):
+        return
+
+    if moving_instance_id is not None:
+        moving_finding = next(
+            (finding for finding in findings if finding.id == moving_instance_id),
+            None,
+        )
+        if moving_finding is not None:
+            if target_position is None:
+                target_position = len(findings)
+            group_size = len(findings)
+            findings = [
+                finding for finding in findings if finding.id != moving_instance_id
+            ]
+            insert_at = _clamp_position(target_position, group_size) - 1
+            findings.insert(insert_at, moving_finding)
+
+    changed_findings = []
+    for position, finding in enumerate(findings, start=1):
+        if finding.position != position:
+            finding.position = position
+            changed_findings.append(finding)
+    if changed_findings:
+        model.objects.bulk_update(changed_findings, ["position"])
+
+
 def set_finding_positions(
-    instance: django.db.models.Model, old_pos: [int, None], old_sev: [int, None], new_pos: int, new_sev: int
+    instance: django.db.models.Model,
+    old_pos: [int, None],
+    old_sev: [int, None],
+    new_pos: int,
+    new_sev: int,
 ) -> None:
     """
     Updates the ``position`` value for a finding in a report. This is used when a finding is moved to a new position or
     changes severity.
 
-    The following adjustments use the queryset ``update()`` method (direct SQL statement) instead of calling ``save()``
-    on the individual model instance. This avoids forever looping through position changes.
+    Ordering is serialized on the parent report row and only writes values
+    that differ. This makes the Hasura events created by reordering converge
+    instead of repeatedly reordering the same group.
 
     **Parameters**
 
@@ -61,55 +151,58 @@ def set_finding_positions(
     ``new_sev``
         The new severity ID assigned to the finding
     """
-    # We don't import the model at the top of the file because it causes a circular import
+    if (
+        old_pos is not None
+        and old_sev is not None
+        and old_pos == new_pos
+        and old_sev == new_sev
+    ):
+        return None
+
     model = instance._meta.model
+    report_model = model._meta.get_field("report").related_model
+    report_id = instance.report_id
 
-    if old_pos and old_sev:
-        # Only run db queries if ``position`` or ``severity`` changed
-        if old_pos != new_pos or old_sev != new_sev:
-            # Get all findings in report that share the instance's severity rating
-            finding_queryset = model.objects.filter(
-                Q(report__pk=instance.report.pk) & Q(severity=instance.severity)
-            ).order_by("position")
+    with transaction.atomic():
+        report_model.objects.select_for_update().get(id=report_id)
+        # The event view obtains ``instance`` before this report lock. Reload
+        # it after the lock so a queued event makes decisions using the state
+        # committed by the event that ran immediately before it.
+        instance.refresh_from_db()
 
-            # If severity rating changed, adjust positioning in the previous severity group
+        if old_pos is not None and old_sev is not None:
+            # A later event can arrive after another event has already moved
+            # the finding. Normalize the current state rather than replaying
+            # that stale event's requested position.
+            if instance.position != new_pos or instance.severity_id != new_sev:
+                for severity_id in sorted(
+                    {old_sev, new_sev, instance.severity_id}
+                ):
+                    _normalize_locked_finding_positions(
+                        model,
+                        report_id,
+                        severity_id,
+                    )
+                return None
+
             if old_sev != new_sev:
-                # Get a list of findings for the old severity rating
-                old_sev_queryset = model.objects.filter(
-                    Q(report__pk=instance.report.pk) & Q(severity=old_sev)
-                ).order_by("position")
-                if old_sev_queryset:
-                    for finding in old_sev_queryset:
-                        # Adjust position to close gap created by moved finding
-                        if finding.position > old_pos:
-                            new_pos = finding.position - 1
-                            old_sev_queryset.filter(id=finding.id).order_by("position").update(position=new_pos)
+                _normalize_locked_finding_positions(model, report_id, old_sev)
 
-            # The ``modelUpdateForm`` sets minimum number to 0, but check again for funny business
-            instance.position = max(instance.position, 1)
-
-            # The ``position`` value should not be larger than total findings
-            if instance.position > finding_queryset.count():
-                finding_queryset.filter(id=instance.id).update(position=finding_queryset.count())
-
-            counter = 1
-            if finding_queryset:
-                # Loop from top position down and look for a match
-                for finding in finding_queryset:
-                    # Check if finding in loop is the finding being updated
-                    if not instance.pk == finding.pk:
-                        # Increment position counter when counter equals new value
-                        if instance.position == counter:
-                            counter += 1
-                        finding_queryset.filter(id=finding.id).update(position=counter)
-                        counter += 1
-                    else:
-                        pass
-            # No other findings with the chosen severity, so set ``position`` to ``1``
-            else:
-                instance.position = 1
-    # Place newly created findings at the end of the current list
-    else:
-        finding_queryset = model.objects.filter(Q(report__pk=instance.report.pk) & Q(severity=instance.severity))
-        finding_queryset.filter(id=instance.id).update(position=finding_queryset.count())
+            _normalize_locked_finding_positions(
+                model,
+                report_id,
+                new_sev,
+                moving_instance_id=instance.id,
+                target_position=new_pos,
+            )
+        else:
+            # Existing behaviour: report findings added through GraphQL are
+            # appended to their severity group regardless of input position.
+            _normalize_locked_finding_positions(
+                model,
+                report_id,
+                new_sev,
+                moving_instance_id=instance.id,
+                skip_if_contiguous=True,
+            )
     return None

--- a/ghostwriter/modules/model_utils.py
+++ b/ghostwriter/modules/model_utils.py
@@ -125,8 +125,8 @@ def _normalize_locked_finding_positions(
 
 def set_finding_positions(
     instance: django.db.models.Model,
-    old_pos: [int, None],
-    old_sev: [int, None],
+    old_pos: Optional[int],
+    old_sev: Optional[int],
     new_pos: int,
     new_sev: int,
 ) -> None:

--- a/javascript/src/collab_server/index.ts
+++ b/javascript/src/collab_server/index.ts
@@ -281,13 +281,17 @@ const server = new Server({
             Object.assign(data.connection.context, refreshedContext);
             currentContext.log.info("Collaboration token refreshed");
 
-            await data.document.saveMutex.runExclusive(async () => {
-                const serverInfo = data.document.get("serverInfo", Y.Map);
+            // Hocuspocus v3.4 declares `data.document` for this hook but
+            // does not populate it at runtime. The connection always owns the
+            // document receiving the token-sync message.
+            const document = data.connection.document;
+            await document.saveMutex.runExclusive(async () => {
+                const serverInfo = document.get("serverInfo", Y.Map);
                 if (serverInfo.get("saveError")) {
                     await storeDocument(
                         currentContext,
                         data.documentName,
-                        data.document
+                        document
                     );
                 }
             });

--- a/javascript/src/collab_server/index.ts
+++ b/javascript/src/collab_server/index.ts
@@ -4,6 +4,10 @@
 
 // Apollo's lib is commonjs and tsx doesn't see its exports, so work around it.
 import * as apollo from "@apollo/client/core";
+import type {
+    ApolloClient as ApolloClientType,
+    NormalizedCacheObject,
+} from "@apollo/client/core";
 const { ApolloClient, createHttpLink, InMemoryCache } = apollo;
 
 import { randomUUID } from "node:crypto";
@@ -21,6 +25,7 @@ import FindingHandler from "./handlers/finding";
 import ReportFindingLinkHandler from "./handlers/report_finding_link";
 import ReportHandler from "./handlers/report";
 import ProjectHandler from "./handlers/project";
+import { setSaveError } from "./save_error";
 
 // Extend this with your model handlers. See how-to-collab.md.
 const HANDLERS_ARR: [string, ModelHandler<any>][] = [
@@ -35,37 +40,44 @@ const HANDLERS: Map<string, ModelHandler<any>> = new Map(HANDLERS_ARR);
 
 // Graphql Client
 
-const graphql_engine_hostname: string = env["HASURA_GRAPHQL_SERVER_HOSTNAME"] || "graphql_engine";
+const graphql_engine_hostname: string =
+    env["HASURA_GRAPHQL_SERVER_HOSTNAME"] || "graphql_engine";
 
 const httpLink = createHttpLink({
-    uri: "http://" + graphql_engine_hostname + ":8080/v1/graphql"
+    uri: "http://" + graphql_engine_hostname + ":8080/v1/graphql",
 });
 
-const authLink = setContext((_, { headers }) => {
-    return {
-        headers: {
-            ...headers,
-            "x-hasura-admin-secret": (env as any)[
-                "HASURA_GRAPHQL_ADMIN_SECRET"
-            ],
-        },
-    };
-});
+function getGqlClient(context: Context) {
+    if (context.gqlClient) return context.gqlClient;
 
-const gqlClient = new ApolloClient({
-    link: authLink.concat(httpLink),
-    cache: new InMemoryCache(),
-    defaultOptions: {
-        query: {
-            fetchPolicy: "no-cache",
-            errorPolicy: "all",
+    const authLink = setContext((_, { headers }) => {
+        return {
+            headers: {
+                ...headers,
+                "x-hasura-admin-secret": (env as any)[
+                    "HASURA_GRAPHQL_ADMIN_SECRET"
+                ],
+                Authorization: "Bearer " + context.token,
+            },
+        };
+    });
+
+    context.gqlClient = new ApolloClient({
+        link: authLink.concat(httpLink),
+        cache: new InMemoryCache(),
+        defaultOptions: {
+            query: {
+                fetchPolicy: "no-cache",
+                errorPolicy: "all",
+            },
+            watchQuery: {
+                fetchPolicy: "no-cache",
+                errorPolicy: "all",
+            },
         },
-        watchQuery: {
-            fetchPolicy: "no-cache",
-            errorPolicy: "all",
-        },
-    },
-});
+    });
+    return context.gqlClient;
+}
 
 // Hocuspocus collab server
 
@@ -73,8 +85,12 @@ const gqlClient = new ApolloClient({
 type Context = {
     model: string;
     id: number;
+    userId: number;
     username: string;
+    token: string;
+    expiresAt: number;
     log: Logger;
+    gqlClient?: ApolloClientType<NormalizedCacheObject>;
 };
 
 class AuthError extends Error {
@@ -86,6 +102,131 @@ class AuthError extends Error {
 
 const BASE_LOGGER = pino({});
 const documentData = new Map<string, unknown>();
+const AUTH_TIMEOUT_MS = 15_000;
+
+type AuthenticationData = {
+    documentName: string;
+    token: string;
+    instance: {
+        documents: ReadonlyMap<string, Y.Doc>;
+    };
+};
+
+async function authenticateConnection(
+    conn: AuthenticationData,
+    log: Logger
+): Promise<Context> {
+    const roomMatch = /^([^/]+)\/([1-9]\d*)$/.exec(conn.documentName);
+    if (roomMatch === null) {
+        throw new AuthError("Invalid room name");
+    }
+
+    const model = roomMatch[1];
+    const id = Number(roomMatch[2]);
+    if (!Number.isSafeInteger(id) || !HANDLERS.has(model)) {
+        throw new AuthError("Unrecognized document");
+    }
+
+    const tokenParts = conn.token.trim().split(/\s+/);
+    if (tokenParts.length !== 1 && tokenParts.length !== 2) {
+        throw new AuthError("Invalid auth token");
+    }
+    const [token, expectedInstanceId = null] = tokenParts;
+
+    const res = await fetch("http://django:8000/api/check_permissions", {
+        method: "POST",
+        signal: AbortSignal.timeout(AUTH_TIMEOUT_MS),
+        body: JSON.stringify({
+            input: {
+                model,
+                id,
+            },
+        }),
+        headers: {
+            "Hasura-Action-Secret": (env as any)["HASURA_ACTION_SECRET"],
+            Authorization: "Bearer " + token,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+    });
+
+    if (res.status !== 200) {
+        const body = await res.text();
+        if (res.status === 401 || res.status === 403) {
+            throw new AuthError("User failed authentication: " + body);
+        }
+        throw new Error("Auth endpoint failed: " + body);
+    }
+
+    const principal = await res.json();
+    if (
+        typeof principal?.username !== "string" ||
+        !Number.isSafeInteger(principal?.userId) ||
+        !Number.isSafeInteger(principal?.expiresAt) ||
+        principal.expiresAt * 1000 <= Date.now()
+    ) {
+        throw new Error(
+            "Invalid data from auth endpoint " + JSON.stringify(principal)
+        );
+    }
+
+    if (expectedInstanceId !== null) {
+        // Refuse to merge a client document with a divergent server history.
+        const existingDoc = conn.instance.documents.get(conn.documentName);
+        if (!existingDoc) {
+            throw new AuthError("client expecting a loaded document");
+        }
+
+        let instanceId;
+        existingDoc.transact(() => {
+            instanceId = existingDoc.get("serverInfo", Y.Map).get("instanceId");
+        });
+
+        if (expectedInstanceId !== instanceId) {
+            throw new AuthError("expected document instance ID mismatch");
+        }
+    }
+
+    return {
+        model,
+        id,
+        userId: principal.userId,
+        username: principal.username,
+        token,
+        expiresAt: principal.expiresAt,
+        log,
+    };
+}
+
+function requireValidToken(context: Context) {
+    if (context.expiresAt * 1000 <= Date.now()) {
+        throw new AuthError("Collaboration token expired");
+    }
+}
+
+async function storeDocument(
+    context: Context,
+    documentName: string,
+    document: Y.Doc
+) {
+    try {
+        requireValidToken(context);
+        const docData = documentData.get(documentName);
+        context.log.info("Saving document");
+        const handler = HANDLERS.get(context.model)!;
+        await handler.save(
+            getGqlClient(context),
+            context.id,
+            document,
+            docData
+        );
+    } catch (e) {
+        context.log.error({ msg: "Could not save document", err: e });
+        setSaveError(document, true);
+        return;
+    }
+    setSaveError(document, false);
+}
 
 const server = new Server({
     port: 8000,
@@ -108,97 +249,10 @@ const server = new Server({
             socketId: conn.socketId,
         });
         try {
-            const roomSplit = conn.documentName.split("/", 2);
-            if (roomSplit.length !== 2) {
-                throw new AuthError("Invalid room name");
-            }
-            const model = roomSplit[0];
-            const id = parseInt(roomSplit[1]);
-            if (id !== id) {
-                throw new AuthError("Invalid room name: Invalid ID");
-            }
-
-            if (!HANDLERS.has(model)) {
-                throw new AuthError("Unrecognized model: " + model);
-            }
-
-            const tokenParts = conn.token.split(" ");
-            if (tokenParts.length !== 1 && tokenParts.length !== 2) {
-                throw new AuthError("Invalid auth token");
-            }
-            const token = tokenParts[0];
-            const expectedInstanceId =
-                tokenParts.length >= 2 ? tokenParts[1] : null;
-
-            const res = await fetch(
-                "http://django:8000/api/check_permissions",
-                {
-                    method: "POST",
-                    body: JSON.stringify({
-                        input: {
-                            model,
-                            id,
-                        },
-                    }),
-                    headers: {
-                        "Hasura-Action-Secret": (env as any)[
-                            "HASURA_ACTION_SECRET"
-                        ],
-                        Authorization: "Bearer " + token,
-                        "Content-Type": "application/json",
-                        Accept: "application/json",
-                    },
-                }
-            );
-
-            if (res.status !== 200) {
-                const body = await res.text();
-                if (res.status === 403)
-                    throw new AuthError("User failed authentication: " + body);
-                throw new Error("Auth endpoint failed:" + body);
-            }
-
-            const username = await res.json();
-            if (typeof username !== "string") {
-                throw new Error(
-                    "Invalid data from auth endpoint " +
-                        JSON.stringify(username)
-                );
-            }
-            log.setBindings({ username });
-
-            if (expectedInstanceId !== null) {
-                // If a client was working with a previous version of the document, make sure the one
-                // on the server matches, otherwise it'll try to merge two divergent yjs docs, which
-                // causes weird results. Kick them out and make them reload if that happens.
-                const existingDoc = conn.instance.documents.get(
-                    conn.documentName
-                );
-                if (!existingDoc) {
-                    throw new AuthError("client expecting a loaded document");
-                }
-
-                let instanceId;
-                existingDoc.transact(() => {
-                    instanceId = existingDoc
-                        .get("serverInfo", Y.Map)
-                        .get("instanceId");
-                });
-
-                if (expectedInstanceId !== instanceId) {
-                    throw new AuthError(
-                        "expected document instance ID mismatch"
-                    );
-                }
-            }
-
+            const context = await authenticateConnection(conn, log);
+            log.setBindings({ username: context.username });
             log.info("Client authenticated");
-            return {
-                model,
-                id,
-                username,
-                log,
-            } as Context; // data.context
+            return context;
         } catch (e) {
             if (e instanceof AuthError) {
                 log.error({
@@ -211,13 +265,52 @@ const server = new Server({
         }
     },
 
+    async onTokenSync(data) {
+        const currentContext = data.context as Context;
+        try {
+            const refreshedContext = await authenticateConnection(
+                data,
+                currentContext.log
+            );
+            if (refreshedContext.userId !== currentContext.userId) {
+                throw new AuthError("Collaboration user changed");
+            }
+
+            // Mutate the existing object so any debounced save that already
+            // captured this context also receives the renewed credential.
+            Object.assign(data.connection.context, refreshedContext);
+            currentContext.log.info("Collaboration token refreshed");
+
+            await data.document.saveMutex.runExclusive(async () => {
+                const serverInfo = data.document.get("serverInfo", Y.Map);
+                if (serverInfo.get("saveError")) {
+                    await storeDocument(
+                        currentContext,
+                        data.documentName,
+                        data.document
+                    );
+                }
+            });
+        } catch (e) {
+            currentContext.log.error({
+                msg: "Could not refresh collaboration token",
+                err: e,
+            });
+            throw e;
+        }
+    },
+
     async onLoadDocument(data) {
         const context = data.context as Context;
         try {
+            requireValidToken(context);
             context.log.info("Loading document");
 
             const handler = HANDLERS.get(context.model)!;
-            const [doc, docData] = await handler.load(gqlClient, context.id);
+            const [doc, docData] = await handler.load(
+                getGqlClient(context),
+                context.id
+            );
             doc.transact((tx) => {
                 const serverInfo = tx.doc.get("serverInfo", Y.Map);
                 // Embed an ID unique to this particular yjs doc, so a client working with an older version
@@ -236,21 +329,7 @@ const server = new Server({
 
     async onStoreDocument(data) {
         const context = data.context as Context;
-        try {
-            const docData = documentData.get(data.documentName);
-            context.log.info("Saving document");
-            const handler = HANDLERS.get(context.model)!;
-            await handler.save(gqlClient, context.id, data.document, docData);
-        } catch (e) {
-            context.log.error({ msg: "Could not save document", err: e });
-            data.document.transact((tx) => {
-                tx.doc.get("serverInfo", Y.Map).set("saveError", true);
-            });
-            return;
-        }
-        data.document.transact((tx) => {
-            tx.doc.get("serverInfo", Y.Map).set("saveError", false);
-        });
+        await storeDocument(context, data.documentName, data.document);
     },
 
     async onDisconnect(data) {

--- a/javascript/src/collab_server/index.ts
+++ b/javascript/src/collab_server/index.ts
@@ -152,7 +152,7 @@ async function authenticateConnection(
 
     if (res.status !== 200) {
         const body = await res.text();
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 400 || res.status === 401 || res.status === 403) {
             throw new AuthError("User failed authentication: " + body);
         }
         throw new Error("Auth endpoint failed: " + body);

--- a/javascript/src/collab_server/save_error.ts
+++ b/javascript/src/collab_server/save_error.ts
@@ -1,0 +1,11 @@
+import * as Y from "yjs";
+
+/** Update the shared save-error flag only when its value has changed. */
+export function setSaveError(document: Y.Doc, value: boolean): void {
+    const serverInfo = document.get("serverInfo", Y.Map);
+    if (serverInfo.get("saveError") === value) return;
+
+    document.transact(() => {
+        serverInfo.set("saveError", value);
+    });
+}

--- a/javascript/src/frontend/collab_forms/connection.tsx
+++ b/javascript/src/frontend/collab_forms/connection.tsx
@@ -4,6 +4,7 @@ import {
     HocuspocusProviderWebsocket,
 } from "@hocuspocus/provider";
 import * as Y from "yjs";
+import { getCollabToken, subscribeCollabToken } from "./token";
 
 export type ConnectionStatus =
     | "disconnected"
@@ -50,7 +51,6 @@ export function usePageConnection(settings: {
         const id =
             settings.id ?? document.getElementById("yjs-object-id")!.innerHTML;
         const username = document.getElementById("yjs-username")!.innerHTML;
-        const jwt = document.getElementById("yjs-jwt")!.innerHTML;
 
         provider.current = new HocuspocusProvider({
             websocketProvider: new HocuspocusProviderWebsocket({
@@ -58,8 +58,8 @@ export function usePageConnection(settings: {
                 autoConnect: false,
             }),
             name: settings.model + "/" + id,
-            token() {
-                let tok = jwt;
+            async token() {
+                let tok = await getCollabToken();
 
                 // Send document instance ID so that server will kick us out if it's made a new document with
                 // a divergent history.
@@ -105,9 +105,17 @@ export function usePageConnection(settings: {
     }
 
     useEffect(() => {
+        const unsubscribeToken = subscribeCollabToken((event) => {
+            if (event === "refreshed" && provider.current.isAuthenticated) {
+                void provider.current.sendToken();
+            } else if (event === "expired") {
+                provider.current.configuration.websocketProvider.disconnect();
+            }
+        });
         provider.current!.attach();
         provider.current!.configuration.websocketProvider.connect();
         return () => {
+            unsubscribeToken();
             provider.current?.destroy();
             (window as any).gwDebugYjsProvider = null;
         };

--- a/javascript/src/frontend/collab_forms/token.ts
+++ b/javascript/src/frontend/collab_forms/token.ts
@@ -1,0 +1,230 @@
+const REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const REFRESH_RETRY_MS = 30 * 1000;
+const REFRESH_TIMEOUT_MS = 15 * 1000;
+const MAX_TIMER_MS = 2_147_483_647;
+
+type CollabTokenEvent = "refreshed" | "expired";
+type CollabTokenListener = (event: CollabTokenEvent) => void;
+
+class CollabTokenRefreshError extends Error {
+    constructor(
+        message: string,
+        readonly terminal: boolean
+    ) {
+        super(message);
+        this.name = "CollabTokenRefreshError";
+    }
+}
+
+let currentToken: string | null = null;
+let expiresAtMs = 0;
+let initialized = false;
+let refreshPromise: Promise<string> | null = null;
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+let nextRefreshAttemptAt = 0;
+const listeners = new Set<CollabTokenListener>();
+
+function requiredElementText(id: string): string {
+    const value = document.getElementById(id)?.textContent?.trim();
+    if (!value) {
+        throw new Error(`Missing collaboration setting: ${id}`);
+    }
+    return value;
+}
+
+function tokenExpiration(token: string): number {
+    try {
+        const encodedPayload = token.split(".")[1];
+        const padding = "=".repeat((4 - (encodedPayload.length % 4)) % 4);
+        const payload = JSON.parse(
+            atob(encodedPayload.replace(/-/g, "+").replace(/_/g, "/") + padding)
+        );
+        if (typeof payload.exp === "number") {
+            return payload.exp * 1000;
+        }
+    } catch {
+        // The server will authoritatively validate the token. This parsing is
+        // only used to schedule renewal in the browser.
+    }
+    throw new Error("Collaboration token has no valid expiration");
+}
+
+function initialize() {
+    if (initialized) return;
+    currentToken = requiredElementText("yjs-jwt");
+    expiresAtMs = tokenExpiration(currentToken);
+    initialized = true;
+    scheduleRefresh();
+}
+
+function notify(event: CollabTokenEvent) {
+    listeners.forEach((listener) => listener(event));
+}
+
+function expireToken() {
+    if (currentToken === null) return;
+    currentToken = null;
+    if (refreshTimer !== null) clearTimeout(refreshTimer);
+    refreshTimer = null;
+    notify("expired");
+}
+
+function handleRefreshFailure(error: unknown) {
+    if (error instanceof CollabTokenRefreshError && error.terminal) {
+        expireToken();
+        return;
+    }
+
+    const remainingMs = expiresAtMs - Date.now();
+    if (remainingMs <= 0) {
+        expireToken();
+        return;
+    }
+    const retryDelay = Math.min(REFRESH_RETRY_MS, remainingMs);
+    nextRefreshAttemptAt = Date.now() + retryDelay;
+    scheduleRefresh(retryDelay);
+}
+
+function scheduleRefresh(delayOverride?: number) {
+    if (currentToken === null) return;
+    if (refreshTimer !== null) clearTimeout(refreshTimer);
+
+    const remainingMs = expiresAtMs - Date.now();
+    if (remainingMs <= 0) {
+        expireToken();
+        return;
+    }
+
+    const delay = delayOverride ?? Math.max(0, remainingMs - REFRESH_WINDOW_MS);
+    refreshTimer = setTimeout(
+        () => {
+            refreshTimer = null;
+            void refreshCollabToken().catch(handleRefreshFailure);
+        },
+        Math.min(delay, MAX_TIMER_MS)
+    );
+}
+
+async function requestCollabToken(): Promise<string> {
+    const csrfToken = document.querySelector<HTMLMetaElement>(
+        'meta[name="csrf-token"]'
+    )?.content;
+    if (!csrfToken) {
+        throw new CollabTokenRefreshError(
+            "Missing collaboration CSRF token",
+            true
+        );
+    }
+
+    const abortController = new AbortController();
+    const timeout = setTimeout(
+        () => abortController.abort(),
+        REFRESH_TIMEOUT_MS
+    );
+    let response: Response;
+    let data: unknown;
+    try {
+        response = await fetch(
+            requiredElementText("collab-token-refresh-url"),
+            {
+                method: "POST",
+                credentials: "same-origin",
+                signal: abortController.signal,
+                headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": csrfToken,
+                },
+                body: JSON.stringify({
+                    model: requiredElementText("yjs-model"),
+                    id: requiredElementText("yjs-object-id"),
+                }),
+            }
+        );
+
+        if (response.ok) data = await response.json();
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+        throw new CollabTokenRefreshError(
+            `Collaboration token renewal failed (${response.status})`,
+            response.status >= 400 &&
+                response.status < 500 &&
+                response.status !== 408 &&
+                response.status !== 429
+        );
+    }
+
+    if (
+        typeof data !== "object" ||
+        data === null ||
+        typeof (data as { token?: unknown }).token !== "string" ||
+        typeof (data as { expiresAt?: unknown }).expiresAt !== "number"
+    ) {
+        throw new CollabTokenRefreshError(
+            "Collaboration token renewal returned invalid data",
+            false
+        );
+    }
+
+    const token = (data as { token: string }).token;
+    const responseExpiration = (data as { expiresAt: number }).expiresAt * 1000;
+    const parsedExpiration = tokenExpiration(token);
+    if (
+        responseExpiration <= Date.now() ||
+        Math.abs(responseExpiration - parsedExpiration) > 1000
+    ) {
+        throw new CollabTokenRefreshError(
+            "Collaboration token renewal returned an invalid expiration",
+            false
+        );
+    }
+
+    currentToken = token;
+    expiresAtMs = responseExpiration;
+    nextRefreshAttemptAt = 0;
+    scheduleRefresh();
+    notify("refreshed");
+    return token;
+}
+
+async function refreshCollabToken(): Promise<string> {
+    initialize();
+    if (refreshPromise !== null) return refreshPromise;
+
+    const request = requestCollabToken();
+    refreshPromise = request;
+    try {
+        return await request;
+    } finally {
+        if (refreshPromise === request) refreshPromise = null;
+    }
+}
+
+export async function getCollabToken(): Promise<string> {
+    initialize();
+    if (currentToken === null) {
+        throw new Error("Collaboration authentication expired");
+    }
+
+    if (
+        expiresAtMs - Date.now() <= REFRESH_WINDOW_MS &&
+        Date.now() >= nextRefreshAttemptAt
+    ) {
+        try {
+            return await refreshCollabToken();
+        } catch (error) {
+            handleRefreshFailure(error);
+            if (currentToken === null) throw error;
+        }
+    }
+    return currentToken;
+}
+
+export function subscribeCollabToken(listener: CollabTokenListener) {
+    initialize();
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}

--- a/javascript/src/frontend/graphql/client.tsx
+++ b/javascript/src/frontend/graphql/client.tsx
@@ -6,18 +6,19 @@ import {
 } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { useMemo } from "react";
+import { getCollabToken } from "../collab_forms/token";
 
 export default function PageGraphqlProvider(props: {
     children: React.ReactNode;
 }) {
     const client = useMemo(() => {
         const path = document.getElementById("graphql-path")!.innerHTML;
-        const auth = document.getElementById("graphql-auth")!.innerHTML;
 
         const httpLink = createHttpLink({
             uri: window.location.protocol + "//" + window.location.host + path,
         });
-        const authLink = setContext((_, { headers }) => {
+        const authLink = setContext(async (_, { headers }) => {
+            const auth = await getCollabToken();
             return {
                 headers: {
                     ...headers,

--- a/javascript/tests/e2e/collab_save_error.spec.ts
+++ b/javascript/tests/e2e/collab_save_error.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import * as Y from "yjs";
+
+import { setSaveError } from "../../src/collab_server/save_error";
+
+test("collab save-error state emits updates only when it changes", () => {
+    const document = new Y.Doc();
+    const serverInfo = document.get("serverInfo", Y.Map);
+    serverInfo.set("saveError", false);
+
+    let updateCount = 0;
+    document.on("update", () => {
+        updateCount += 1;
+    });
+
+    setSaveError(document, false);
+    expect(updateCount).toBe(0);
+
+    setSaveError(document, true);
+    setSaveError(document, true);
+    expect(updateCount).toBe(1);
+
+    setSaveError(document, false);
+    setSaveError(document, false);
+    expect(updateCount).toBe(2);
+});


### PR DESCRIPTION
Closes #924 and closes #926.

## Summary

- Serializes and deterministically normalizes report finding positions so bulk inserts and out-of-order Hasura events converge without self-sustaining writes.
- Uses a single bulk update for changed positions, leaving follow-up events as no-ops.
- Renews document-scoped collaboration JWTs in place through the authenticated Django session, preserving immediate Yjs updates without reconnecting the editor.
- Avoids redundant Yjs save-error transactions when the shared error state has not changed.

## Root cause

A Hasura event trigger observes report-finding inserts and position or severity updates. The previous unlocked per-row reordering could race on duplicate positions, generate further position updates, and enqueue additional event invocations. Under bulk inserts, this became a feedback loop that created excessive database activity and logs.

## Security and auth

Each collaboration JWT remains document-scoped and valid for no more than 24 hours. Renewal requires an active Django session, CSRF validation, and a fresh object-level edit-permission check. No internal Hasura secret is used as a user identity credential.

## Validation

- 296 affected Django view tests passed, including concurrent event delivery and token-scope coverage.
- TypeScript check and frontend/collaboration-server builds passed.
- Focused Playwright regression for save-error state passed.
- Two-tab live editing, persistence, token rotation, and evidence modal behavior were exercised locally.

## Release notes

Fixed an event feedback loop that could generate excessive Hasura logs and database activity while ordering bulk-created report findings.