### PR TITLE
Fix nested DOCX table handling and upload master coverage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,15 @@ name: Run Unit Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "**.md"
+      - "**.mdx"
+      - "**.html"
+      - "**.css"
+      - "DOCS/**"
   pull_request:
     branches:
       - master
@@ -71,6 +80,22 @@ jobs:
           name: coverage-report
           path: coverage/reports/coverage.xml
 
+  upload-coverage-report:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    needs: run-unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage-report
+          path: coverage/reports
+
       - name: Check Codecov token availability
         id: codecov
         env:
@@ -87,6 +112,8 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/reports/coverage.xml
+          disable_search: true
           name: codecov-ghostwriter
           fail_ci_if_error: true
           verbose: true

--- a/ghostwriter/modules/reportwriter/richtext/docx.py
+++ b/ghostwriter/modules/reportwriter/richtext/docx.py
@@ -9,12 +9,13 @@ from django.conf import settings
 
 # 3rd Party Libraries
 import docx
+from docx.document import Document as DocumentObject
 from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_BREAK, WD_COLOR_INDEX
 from docx.image.exceptions import UnrecognizedImageError
 from docx.oxml.shared import OxmlElement, qn
 from docx.shared import Inches, Pt
 from docx.shared import RGBColor as DocxRgbColor
-from docx.document import Document as DocumentObject
+from docx.table import _Cell
 from lxml import etree
 
 # Ghostwriter Libraries
@@ -402,7 +403,9 @@ class HtmlToDocx(BaseHtmlToOOXML):
     def create_table(self, rows, cols, **kwargs):
         par = kwargs.get("par")
         table_parent = getattr(par, "_parent", None)
-        if table_parent is None or not hasattr(table_parent, "add_table"):
+        # The document body also exposes an internal add_table method, but it
+        # requires a width argument. Only table cells support this nested API.
+        if not isinstance(table_parent, _Cell):
             table_parent = self.doc
         table = table_parent.add_table(rows=rows, cols=cols)
         table.style = "Table Grid"

--- a/ghostwriter/reporting/tests/test_rich_text_docx.py
+++ b/ghostwriter/reporting/tests/test_rich_text_docx.py
@@ -144,6 +144,30 @@ class RichTextToDocxTests(SimpleTestCase):
         )
         self.assertEqual([paragraph.text for paragraph in doc.paragraphs], [])
 
+    def test_tables_inside_body_blocks_use_the_document_container(self):
+        cases = {
+            "blockquote": (
+                "<blockquote><table><tr><td><p>NESTED</p></td></tr></table></blockquote>"
+            ),
+            "bullet list": (
+                "<ul><li><table><tr><td><p>NESTED</p></td></tr></table></li></ul>"
+            ),
+        }
+
+        for name, html in cases.items():
+            with self.subTest(name=name):
+                doc = docx.Document()
+                HtmlToDocx.run(html, doc, None)
+
+                self.assertEqual(len(doc.tables), 1)
+                self.assertEqual(
+                    [
+                        paragraph.text
+                        for paragraph in doc.tables[0].cell(0, 0).paragraphs
+                    ],
+                    ["NESTED"],
+                )
+
     def test_table_cell_block_elements_remain_in_the_cell(self):
         cases = {
             "blockquote": (


### PR DESCRIPTION
## Summary

- Correct nested table creation for blockquotes and list items in DOCX exports.
- Add regression coverage for tables inside body-level blocks and preserve table-cell nesting.
- Run coverage uploads on successful `master` pushes using the generated coverage artifact.
- Ignore documentation and presentation-only changes for push-triggered test runs.

## Testing

- Added regression tests for nested DOCX tables.
- Not run (not requested).