### PR TITLE
Add a comments plugin to tiptap

### DIFF
--- a/javascript/src/frontend/collab_forms/editor.scss
+++ b/javascript/src/frontend/collab_forms/editor.scss
@@ -484,3 +484,99 @@ ul.collab-focused-users {
 .passive-voice-highlight.passive-voice-hover {
     background-color: #ffe69c;
 }
+
+// Comment mark — active (unresolved) comments get a yellow background
+.gw-comment {
+    background-color: #fff3b0;
+    border-bottom: 2px solid #f0ad00;
+    cursor: pointer;
+}
+
+// Resolved comments lose the highlight but the data stays in the DOM
+.gw-comment.gw-comment-resolved {
+    background-color: transparent;
+    border-bottom: 2px solid #aaa;
+}
+
+// Comment modal card styles
+.gw-comment-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.gw-comment-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+    padding: 0.6rem 0.75rem;
+    background-color: #f8f9fa;
+
+    &.gw-comment-card-own {
+        border-color: #0d6efd;
+        background-color: #f0f5ff;
+    }
+}
+
+.gw-comment-card-header {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.gw-comment-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+.gw-comment-meta {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+
+    strong {
+        font-size: 0.9rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    small {
+        font-size: 0.75rem;
+    }
+}
+
+.gw-comment-actions {
+    display: flex;
+    flex-direction: row;
+    gap: 0.25rem;
+    flex-shrink: 0;
+}
+
+.gw-comment-text {
+    margin: 0;
+    font-size: 0.9rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.gw-comment-edit-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.gw-comment-edit-buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 0.25rem;
+}

--- a/javascript/src/frontend/collab_forms/editor.scss
+++ b/javascript/src/frontend/collab_forms/editor.scss
@@ -492,6 +492,11 @@ ul.collab-focused-users {
     cursor: pointer;
 }
 
+[data-theme="dark"] .gw-comment {
+    background-color: #4a3e00;
+    border-bottom-color: #c8940a;
+}
+
 // Resolved comments lose the highlight but the data stays in the DOM
 .gw-comment.gw-comment-resolved {
     background-color: transparent;
@@ -519,6 +524,16 @@ ul.collab-focused-users {
     &.gw-comment-card-own {
         border-color: #0d6efd;
         background-color: #f0f5ff;
+    }
+}
+
+[data-theme="dark"] .gw-comment-card {
+    border-color: #444;
+    background-color: #2a2a2a;
+
+    &.gw-comment-card-own {
+        border-color: #3a7fd5;
+        background-color: #1a2a3a;
     }
 }
 

--- a/javascript/src/frontend/collab_forms/rich_text_editor/comment.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/comment.tsx
@@ -1,0 +1,372 @@
+import { faComment } from "@fortawesome/free-solid-svg-icons/faComment";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Editor } from "@tiptap/core";
+import { useEditorState } from "@tiptap/react";
+import { useEffect, useId, useRef, useState } from "react";
+import ReactModal from "react-modal";
+import { type CommentEntry } from "../../../tiptap_gw/comment";
+
+function getCurrentUsername(): string {
+    return (
+        document.getElementById("yjs-username")?.textContent?.trim() ??
+        "Unknown"
+    );
+}
+
+function formatTimestamp(iso: string): string {
+    try {
+        return new Date(iso).toLocaleString();
+    } catch {
+        return iso;
+    }
+}
+
+interface CommentCardProps {
+    entry: CommentEntry;
+    currentUser: string;
+    onEdit: (updated: string) => void;
+    onDelete: () => void;
+}
+
+function CommentCard({
+    entry,
+    currentUser,
+    onEdit,
+    onDelete,
+}: CommentCardProps) {
+    const [editing, setEditing] = useState(false);
+    const [editText, setEditText] = useState(entry.comment);
+    const isOwn = entry.author === currentUser;
+    const fieldId = useId();
+
+    return (
+        <div
+            className={`gw-comment-card ${isOwn ? "gw-comment-card-own" : ""}`}
+        >
+            <div className="gw-comment-card-header">
+                <img
+                    className="gw-comment-avatar"
+                    src={`/users/${encodeURIComponent(entry.author)}/avatar`}
+                    alt={`${entry.author} avatar`}
+                    onError={(e) => {
+                        (e.currentTarget as HTMLImageElement).style.display =
+                            "none";
+                    }}
+                />
+                <div className="gw-comment-meta">
+                    <strong>{entry.author}</strong>
+                    <small className="text-muted">
+                        {formatTimestamp(entry.timestamp)}
+                    </small>
+                </div>
+                {isOwn && !editing && (
+                    <div className="gw-comment-actions">
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary"
+                            onClick={() => {
+                                setEditText(entry.comment);
+                                setEditing(true);
+                            }}
+                        >
+                            Edit
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-outline-danger"
+                            onClick={onDelete}
+                        >
+                            Delete
+                        </button>
+                    </div>
+                )}
+            </div>
+            {editing ? (
+                <div className="gw-comment-edit-form">
+                    <label htmlFor={fieldId} className="visually-hidden">
+                        Edit comment
+                    </label>
+                    <textarea
+                        id={fieldId}
+                        className="form-control form-control-sm"
+                        rows={3}
+                        value={editText}
+                        autoFocus
+                        onChange={(e) => setEditText(e.target.value)}
+                    />
+                    <div className="gw-comment-edit-buttons">
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-primary"
+                            disabled={!editText.trim()}
+                            onClick={() => {
+                                onEdit(editText.trim());
+                                setEditing(false);
+                            }}
+                        >
+                            Save
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-secondary"
+                            onClick={() => setEditing(false)}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <p className="gw-comment-text">{entry.comment}</p>
+            )}
+        </div>
+    );
+}
+
+export default function CommentButton({ editor }: { editor: Editor }) {
+    const [modalOpen, setModalOpen] = useState(false);
+    const [comments, setComments] = useState<CommentEntry[]>([]);
+    const [resolved, setResolved] = useState(false);
+    const [newComment, setNewComment] = useState("");
+    const newCommentId = useId();
+
+    // Saved when the modal opens so commands always target the correct span
+    const savedRange = useRef<{ from: number; to: number } | null>(null);
+
+    // Open the modal when the user clicks directly on commented text
+    useEffect(() => {
+        const dom = editor.view.dom;
+        function handleClick(e: MouseEvent) {
+            if (!(e.target as HTMLElement).closest(".gw-comment")) return;
+            // rAF lets ProseMirror update the selection before we read it
+            requestAnimationFrame(() => {
+                if (!editor.isActive("gwComment")) return;
+                editor.chain().focus().extendMarkRange("gwComment").run();
+                const { from, to } = editor.state.selection;
+                savedRange.current = { from, to };
+                const attrs = editor.getAttributes("gwComment");
+                setComments((attrs.comments as CommentEntry[]) ?? []);
+                setResolved((attrs.resolved as boolean) ?? false);
+                setNewComment("");
+                setModalOpen(true);
+            });
+        }
+        dom.addEventListener("click", handleClick);
+        return () => dom.removeEventListener("click", handleClick);
+    }, [editor]);
+
+    const { enabled, active } = useEditorState({
+        editor,
+        selector: ({ editor }) => {
+            if (!editor.isInitialized) return { enabled: false, active: false };
+            const active = editor.isActive("gwComment");
+            const { from, to } = editor.state.selection;
+            return { enabled: active || from !== to, active };
+        },
+    });
+
+    // Apply or remove the gwComment mark directly via ProseMirror transaction
+    function applyComment(entries: CommentEntry[], res: boolean) {
+        const range = savedRange.current;
+        if (!range) return;
+        const { from, to } = range;
+        const markType = editor.schema.marks["gwComment"];
+        if (!markType) return;
+        const tr = editor.state.tr;
+        tr.removeMark(from, to, markType);
+        if (entries.length > 0) {
+            tr.addMark(
+                from,
+                to,
+                markType.create({ comments: entries, resolved: res })
+            );
+        }
+        editor.view.dispatch(tr);
+    }
+
+    function openModal() {
+        if (editor.isActive("gwComment")) {
+            editor.chain().focus().extendMarkRange("gwComment").run();
+            const { from, to } = editor.state.selection;
+            savedRange.current = { from, to };
+            const attrs = editor.getAttributes("gwComment");
+            setComments((attrs.comments as CommentEntry[]) ?? []);
+            setResolved((attrs.resolved as boolean) ?? false);
+        } else {
+            const { from, to } = editor.state.selection;
+            savedRange.current = { from, to };
+            setComments([]);
+            setResolved(false);
+        }
+        setNewComment("");
+        setModalOpen(true);
+    }
+
+    function buildUpdated(): CommentEntry[] {
+        const currentUser = getCurrentUsername();
+        if (!newComment.trim()) return [...comments];
+        return [
+            ...comments,
+            {
+                author: currentUser,
+                comment: newComment.trim(),
+                timestamp: new Date().toISOString(),
+            },
+        ];
+    }
+
+    function handleSave() {
+        applyComment(buildUpdated(), resolved);
+        setModalOpen(false);
+    }
+
+    function handleResolveToggle() {
+        const updated = buildUpdated();
+        if (updated.length > 0) applyComment(updated, !resolved);
+        setModalOpen(false);
+    }
+
+    function handleRemoveAll() {
+        applyComment([], false);
+        setModalOpen(false);
+    }
+
+    function handleEditComment(index: number, updatedText: string) {
+        setComments((prev) =>
+            prev.map((c, i) =>
+                i === index
+                    ? {
+                          ...c,
+                          comment: updatedText,
+                          timestamp: new Date().toISOString(),
+                      }
+                    : c
+            )
+        );
+    }
+
+    function handleDeleteComment(index: number) {
+        setComments((prev) => prev.filter((_, i) => i !== index));
+    }
+
+    const currentUser = getCurrentUsername();
+    const hasExistingComments = comments.length > 0;
+
+    return (
+        <>
+            <button
+                tabIndex={-1}
+                title="Comment"
+                type="button"
+                disabled={!enabled}
+                className={active ? "is-active" : undefined}
+                onClick={(e) => {
+                    e.preventDefault();
+                    openModal();
+                }}
+            >
+                <FontAwesomeIcon icon={faComment} />
+            </button>
+            <ReactModal
+                isOpen={modalOpen}
+                onRequestClose={() => setModalOpen(false)}
+                contentLabel="Comments"
+                className="modal-dialog modal-dialog-centered"
+            >
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <h5 className="modal-title">
+                            {hasExistingComments ? "Comments" : "Add Comment"}
+                        </h5>
+                        {resolved && (
+                            <span className="badge bg-success ms-2">
+                                Resolved
+                            </span>
+                        )}
+                    </div>
+                    <form
+                        className="modal-body"
+                        onSubmit={(ev) => {
+                            ev.preventDefault();
+                            handleSave();
+                        }}
+                    >
+                        {hasExistingComments && (
+                            <div className="gw-comment-list mb-3">
+                                {comments.map((entry, i) => (
+                                    <CommentCard
+                                        key={i}
+                                        entry={entry}
+                                        currentUser={currentUser}
+                                        onEdit={(text) =>
+                                            handleEditComment(i, text)
+                                        }
+                                        onDelete={() => handleDeleteComment(i)}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                        <div className="form-group">
+                            <label htmlFor={newCommentId}>
+                                {hasExistingComments
+                                    ? "Add a reply"
+                                    : "Comment"}
+                            </label>
+                            <textarea
+                                id={newCommentId}
+                                className="form-control"
+                                rows={3}
+                                value={newComment}
+                                autoFocus={!hasExistingComments}
+                                placeholder={
+                                    hasExistingComments
+                                        ? "Write a reply..."
+                                        : "Write a comment..."
+                                }
+                                onChange={(e) => setNewComment(e.target.value)}
+                            />
+                        </div>
+                    </form>
+                    <div className="modal-footer flex-wrap gap-2">
+                        <button
+                            type="button"
+                            className="btn btn-primary"
+                            disabled={
+                                !newComment.trim() && comments.length === 0
+                            }
+                            onClick={handleSave}
+                        >
+                            Save
+                        </button>
+                        {hasExistingComments && (
+                            <>
+                                <button
+                                    type="button"
+                                    className={`btn ${
+                                        resolved ? "btn-warning" : "btn-success"
+                                    }`}
+                                    onClick={handleResolveToggle}
+                                >
+                                    {resolved ? "Unresolve" : "Resolve"}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="btn btn-danger"
+                                    onClick={handleRemoveAll}
+                                >
+                                    Remove All
+                                </button>
+                            </>
+                        )}
+                        <button
+                            type="button"
+                            className="btn btn-secondary"
+                            onClick={() => setModalOpen(false)}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </ReactModal>
+        </>
+    );
+}

--- a/javascript/src/frontend/collab_forms/rich_text_editor/comment.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/comment.tsx
@@ -136,7 +136,9 @@ export default function CommentButton({ editor }: { editor: Editor }) {
     useEffect(() => {
         const dom = editor.view.dom;
         function handleClick(e: MouseEvent) {
-            if (!(e.target as HTMLElement).closest(".gw-comment")) return;
+            const target = e.target;
+            if (!(target instanceof Element)) return;
+            if (!target.closest(".gw-comment")) return;
             // rAF lets ProseMirror update the selection before we read it
             requestAnimationFrame(() => {
                 if (!editor.isActive("gwComment")) return;
@@ -294,7 +296,7 @@ export default function CommentButton({ editor }: { editor: Editor }) {
                             <div className="gw-comment-list mb-3">
                                 {comments.map((entry, i) => (
                                     <CommentCard
-                                        key={i}
+                                        key={`${entry.author}-${entry.timestamp}`}
                                         entry={entry}
                                         currentUser={currentUser}
                                         onEdit={(text) =>

--- a/javascript/src/frontend/collab_forms/rich_text_editor/index.tsx
+++ b/javascript/src/frontend/collab_forms/rich_text_editor/index.tsx
@@ -38,6 +38,7 @@ import Collaboration from "@tiptap/extension-collaboration";
 import CollaborationCaret from "@tiptap/extension-collaboration-caret";
 import EXTENSIONS from "../../../tiptap_gw";
 import LinkButton from "./link";
+import CommentButton from "./comment";
 import HeadingIdButton from "./heading";
 import ColorButton from "./color";
 import { TableCaptionBookmarkButton, TableCellBackgroundColor } from "./table";
@@ -153,6 +154,7 @@ export function Toolbar(props: {
                     <FontAwesomeIcon icon={faCode} />
                 </FormatButton>
                 <LinkButton editor={editor} />
+                <CommentButton editor={editor} />
                 <FormatButton
                     editor={editor}
                     chain={(c) => c.toggleSubscript()}

--- a/javascript/src/tiptap_gw/comment.ts
+++ b/javascript/src/tiptap_gw/comment.ts
@@ -1,0 +1,100 @@
+import { Mark } from "@tiptap/core";
+
+export interface CommentEntry {
+    author: string;
+    comment: string;
+    timestamp: string;
+}
+
+declare module "@tiptap/core" {
+    interface Commands<ReturnType> {
+        gwComment: {
+            setGwComment: (
+                comments: CommentEntry[],
+                resolved?: boolean
+            ) => ReturnType;
+            unsetGwComment: () => ReturnType;
+        };
+    }
+}
+
+export function parseComments(raw: string | null | undefined): CommentEntry[] {
+    if (!raw) return [];
+    try {
+        const parsed = JSON.parse(decodeURIComponent(raw));
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(
+            (c): c is CommentEntry =>
+                typeof c === "object" &&
+                c !== null &&
+                typeof c.author === "string" &&
+                typeof c.comment === "string" &&
+                typeof c.timestamp === "string"
+        );
+    } catch {
+        return [];
+    }
+}
+
+const GwComment = Mark.create({
+    name: "gwComment",
+    // Allow other marks to coexist with comments
+    excludes: "",
+    addAttributes() {
+        return {
+            comments: {
+                default: [],
+                parseHTML: (element) =>
+                    parseComments(element.getAttribute("data-gw-comments")),
+                renderHTML: (attributes) => {
+                    const comments = attributes.comments as CommentEntry[];
+                    if (!Array.isArray(comments) || comments.length === 0)
+                        return {};
+                    return {
+                        "data-gw-comments": encodeURIComponent(
+                            JSON.stringify(comments)
+                        ),
+                    };
+                },
+            },
+            resolved: {
+                default: false,
+                parseHTML: (element) =>
+                    element.hasAttribute("data-gw-comment-resolved"),
+                renderHTML: (attributes) =>
+                    attributes.resolved
+                        ? { "data-gw-comment-resolved": "" }
+                        : {},
+            },
+        };
+    },
+    parseHTML() {
+        return [{ tag: "span[data-gw-comments]" }];
+    },
+    renderHTML({ HTMLAttributes }) {
+        const resolved = "data-gw-comment-resolved" in HTMLAttributes;
+        return [
+            "span",
+            {
+                ...HTMLAttributes,
+                class: resolved
+                    ? "gw-comment gw-comment-resolved"
+                    : "gw-comment",
+            },
+        ];
+    },
+    addCommands() {
+        return {
+            setGwComment:
+                (comments: CommentEntry[], resolved = false) =>
+                ({ commands }) =>
+                    commands.setMark(this.name, { comments, resolved }),
+            unsetGwComment:
+                () =>
+                ({ commands }) =>
+                    commands.unsetMark(this.name),
+        };
+    },
+});
+
+export default GwComment;

--- a/javascript/src/tiptap_gw/comment.ts
+++ b/javascript/src/tiptap_gw/comment.ts
@@ -81,6 +81,7 @@ const GwComment = Mark.create({
                     ? "gw-comment gw-comment-resolved"
                     : "gw-comment",
             },
+            0,
         ];
     },
     addCommands() {

--- a/javascript/src/tiptap_gw/index.ts
+++ b/javascript/src/tiptap_gw/index.ts
@@ -29,6 +29,7 @@ import Footnote from "./footnote";
 import { PassiveVoiceDecoration } from "./passive_voice_decoration";
 import DateTimeShortcuts from "./now_shortcut";
 import JinjaLiteral, { JinjaReference } from "./jinja_literal";
+import GwComment from "./comment";
 
 const EXTENSIONS: Extensions = [
     StarterKit.configure({
@@ -81,6 +82,7 @@ const EXTENSIONS: Extensions = [
     DateTimeShortcuts,
     JinjaLiteral,
     JinjaReference,
+    GwComment,
 ];
 
 export default EXTENSIONS;


### PR DESCRIPTION
Add the ability to add inline comments as requested in this issue https://github.com/GhostManager/Ghostwriter/issues/425

This is a PR for a comments plugin, it follows the same pattern as https://github.com/GhostManager/Ghostwriter/pull/473 and I have tried to address the comments from that PR here (I am having trouble implementing nested comments though)

In any collaborative editor it will allow you to select and comment on text
<img width="176" height="240" alt="image" src="https://github.com/user-attachments/assets/57637993-a590-4a15-ad24-fff83d91771e" />

Once a comment is created it will have the text background will be yellow and will be underlined red (Once resolved the background colour gets removed but is still underlined grey)
<img width="732" height="162" alt="image" src="https://github.com/user-attachments/assets/948a1110-f701-478e-846b-3319b57e1fc7" />

Selecting a comment brings up the model where an owner can edit their own comment and reply, other users cannot edit their comment but can reply
<img width="348" height="392" alt="image" src="https://github.com/user-attachments/assets/0ecd5c07-6b6e-42e7-b1f9-dab2535f011d" />

The added mark is displayed in the tiptap editor only and is not rendered in the generated docx since the reportwriter module strips any unknown HTML spans
<img width="680" height="233" alt="image" src="https://github.com/user-attachments/assets/2f8e556c-95e8-42cc-9a58-48054f21ac82" />
<img width="734" height="161" alt="image" src="https://github.com/user-attachments/assets/6e5838e1-a19d-45e1-a623-f68dba32805e" />