### PR TITLE
Fixed menu bar z-index

### DIFF
--- a/javascript/src/frontend/collab_forms/editor.scss
+++ b/javascript/src/frontend/collab_forms/editor.scss
@@ -33,8 +33,9 @@
 
         font-size: 0.9rem;
 
-        // Show on top of editor items, in particular highlight
-        z-index: 1;
+        // The editor creates a stacking context for collaboration carets. Keep
+        // sticky controls above it so clicks do not pass through after scroll.
+        z-index: 3;
 
         position: sticky;
         top: 0;


### PR DESCRIPTION
This fixes an issue with the Tiptap editor bar's z-index. When we changed z-index for the editor carets, that shifted some layers so now the menu bar can be hard to use when you've scrolled the editor—like when scrolling down the project collab notes.